### PR TITLE
test: remove macOS proxy backpressure race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Restore hosted Linux, macOS, and Windows runner portability across native sandbox, process, Git,
   patch, network, durable registry, and tool-shell test boundaries (#12)
+- Remove the macOS socket-close race from the managed-proxy worker-backpressure conformance test
 
 ### Changed
 - Implement C4 tool system (#13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Restore hosted Linux, macOS, and Windows runner portability across native sandbox, process, Git,
   patch, network, durable registry, and tool-shell test boundaries (#12)
-- Remove the macOS socket-close race from the managed-proxy worker-backpressure conformance test
+- Remove macOS socket-close races from the managed-proxy worker-backpressure conformance test
 
 ### Changed
 - Implement C4 tool system (#13)

--- a/crates/runtime/peritus-network/tests/network.rs
+++ b/crates/runtime/peritus-network/tests/network.rs
@@ -243,23 +243,18 @@ fn worker_bound_applies_backpressure_and_shutdown_joins_the_active_tunnel() {
     let mut active = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     active.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            active,
+        let request = format!(
             "CONNECT loop.test:{port} HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        active.write_all(request.as_bytes()).unwrap();
     });
     assert!(read_head(&mut active).starts_with("HTTP/1.1 200"));
 
     let mut rejected = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     rejected.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
-    proxy.routing_token().expose_header(|token| {
-        write!(
-            rejected,
-            "CONNECT loop.test:{port} HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
-    });
+    // Worker backpressure is enforced when the connection is accepted, before
+    // request parsing. Reading the response directly avoids racing a request
+    // write against the intentional close of the rejected socket.
     assert!(read_head(&mut rejected).starts_with("HTTP/1.1 503"));
     let observations = proxy.observations();
     assert!(observations.windows(2).all(|pair| pair[0].sequence() < pair[1].sequence()));

--- a/crates/runtime/peritus-network/tests/network/support.rs
+++ b/crates/runtime/peritus-network/tests/network/support.rs
@@ -263,7 +263,9 @@ pub fn secret_reference(value: &[u8]) -> SecretReference {
 }
 
 pub fn read_head(stream: &mut TcpStream) -> String {
-    stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    if stream.read_timeout().unwrap().is_none() {
+        stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    }
     let mut bytes = Vec::new();
     let mut byte = [0; 1];
     while !bytes.ends_with(b"\r\n\r\n") {


### PR DESCRIPTION
## Summary
- buffer the admitted CONNECT request before writing it
- read the accept-level worker-limit 503 without sending a request to the intentionally rejected socket
- record the hosted macOS runner repair in the changelog

## Root cause
The worker-bound conformance test wrote an HTTP request to a socket the proxy rejects immediately at accept time. macOS can complete that intentional close while the fixture is still writing, yielding EPIPE or stalling the test around the close race. The proxy behavior is unchanged; the fixture now tests the actual accept-level backpressure contract directly.

## Verification
- cargo fmt --all -- --check
- CARGO_BUILD_JOBS=2 cargo clippy -p peritus-network --all-targets --all-features -- -D warnings
- CARGO_BUILD_JOBS=2 cargo test -p peritus-network --all-features
- CARGO_BUILD_JOBS=2 cargo build -p peritus-network --all-targets --all-features
- 20 consecutive full peritus-network integration-test runs