### PR TITLE
test: stabilize Windows shell completion polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Restore hosted Linux, macOS, and Windows runner portability across native sandbox, process, Git,
   patch, network, durable registry, and tool-shell test boundaries (#12)
 - Remove macOS socket-close races from the managed-proxy worker-backpressure conformance test
+- Stabilize hosted Windows native shell conformance polling under runner scheduling delays
 
 ### Changed
 - Implement C4 tool system (#13)

--- a/crates/tools/peritus-tools-shell/tests/execution_integration.rs
+++ b/crates/tools/peritus-tools-shell/tests/execution_integration.rs
@@ -6,7 +6,11 @@ mod integration_support;
 mod process_authority;
 mod router_authority;
 
-use std::{sync::Arc, thread, time::Duration};
+use std::{
+    sync::Arc,
+    thread,
+    time::{Duration, Instant},
+};
 
 use integration_support::{NativeBackend, quality_plan, shell_plan};
 use peritus_artifact_store::{ArtifactStore, StoreConfig};
@@ -327,14 +331,18 @@ fn artifact_store(root: &process_authority::TestRoot) -> ArtifactStore {
 }
 
 fn await_result(router: &mut ToolRouter, handle: InvocationHandle, first_tick: u64) -> ToolResult {
-    for tick in first_tick..70 {
+    let began = Instant::now();
+    let deadline = Duration::from_secs(10);
+    let mut tick = first_tick;
+    while began.elapsed() < deadline {
         let update = router.poll(handle, instant(tick)).expect("poll execution");
         if let Some(result) = update.terminal() {
             return result.clone();
         }
+        tick = tick.checked_add(1).expect("test authority tick overflow");
         thread::sleep(Duration::from_millis(10));
     }
-    panic!("execution did not terminate before the test authority deadline")
+    panic!("execution did not terminate within the ten-second test deadline")
 }
 
 fn candidate_outcome(result: &ToolResult) -> String {


### PR DESCRIPTION
## Summary
- replace the fixed 48-attempt native shell polling loop with a ten-second wall-clock test deadline
- keep authority instants monotonic while polling
- record the hosted Windows runner repair in the changelog

## Root cause
The integration fixture treated a fixed number of polls as a deadline. On a loaded Windows runner, individual polls took longer and the test exhausted 48 attempts before the native process completion was observed. Production execution deadlines and process semantics are unchanged.

## Verification
- cargo fmt --all -- --check
- CARGO_BUILD_JOBS=2 cargo clippy -p peritus-tools-shell --all-targets --all-features -- -D warnings
- CARGO_BUILD_JOBS=2 cargo test -p peritus-tools-shell --all-features
- CARGO_BUILD_JOBS=2 cargo build -p peritus-tools-shell --all-targets --all-features
- 20 consecutive native shell integration executions