### PR TITLE
test: stabilize hosted network and process fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   patch, network, durable registry, and tool-shell test boundaries (#12)
 - Remove macOS socket-close races from the managed-proxy worker-backpressure conformance test
 - Stabilize hosted Windows native shell conformance polling under runner scheduling delays
+- Make managed-proxy HTTP fixtures issue each complete request in one socket write, and preserve the
+  process cleanup regression's timing distinction with realistic hosted-runner scheduling allowance
 
 ### Changed
 - Implement C4 tool system (#13)

--- a/crates/runtime/peritus-network/tests/network.rs
+++ b/crates/runtime/peritus-network/tests/network.rs
@@ -91,11 +91,10 @@ fn managed_proxy_forwards_http_injects_scoped_credential_and_joins() {
     .unwrap();
     let mut client = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "GET http://loop.test:{port}/value HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     let response = String::from_utf8(read_to_close(&mut client)).unwrap();
     assert!(response.ends_with("OK"));
@@ -141,11 +140,10 @@ fn managed_proxy_connect_tunnels_bidirectionally_and_joins_both_relays() {
     let mut client = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     client.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "CONNECT loop.test:{port} HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     assert!(read_head(&mut client).starts_with("HTTP/1.1 200"));
     client.write_all(b"ping").unwrap();
@@ -192,11 +190,10 @@ fn proxy_shutdown_cancels_an_active_connect_and_joins_the_worker() {
     let mut client = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     client.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "CONNECT loop.test:{port} HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     assert!(read_head(&mut client).starts_with("HTTP/1.1 200"));
     let shutdown = proxy.shutdown().unwrap();
@@ -279,11 +276,10 @@ fn managed_proxy_denies_unlisted_destination_before_resolution_or_connect() {
             .unwrap();
     let mut client = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "CONNECT denied.test:{port} HTTP/1.1\r\nHost: denied.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     let response = read_to_close(&mut client);
     assert!(response.is_empty());
@@ -327,11 +323,10 @@ fn connect_byte_ceiling_stops_the_tunnel_and_reports_a_limited_close() {
     .unwrap();
     let mut client = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "CONNECT loop.test:{port} HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     assert!(read_head(&mut client).starts_with("HTTP/1.1 200"));
     let _ = client.write_all(b"ping");

--- a/crates/runtime/peritus-network/tests/network/policy.rs
+++ b/crates/runtime/peritus-network/tests/network/policy.rs
@@ -134,11 +134,10 @@ fn inherited_listener_bridge_accepts_inside_namespace_and_connects_from_parent()
     assert_eq!(proxy.endpoint(), Some(endpoint));
     let mut client = TcpStream::connect(endpoint.socket_addr()).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "GET http://loop.test:{upstream_port}/value HTTP/1.1\r\nHost: loop.test:{upstream_port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     let mut response = String::new();
     client.read_to_string(&mut response).unwrap();

--- a/crates/runtime/peritus-network/tests/network/redirects.rs
+++ b/crates/runtime/peritus-network/tests/network/redirects.rs
@@ -10,11 +10,10 @@ fn managed_proxy_revalidates_and_suppresses_a_denied_absolute_redirect() {
     let upstream_task = thread::spawn(move || {
         let (mut stream, _) = upstream.accept().unwrap();
         let _ = read_head(&mut stream);
-        write!(
-            stream,
+        let response = format!(
             "HTTP/1.1 302 Found\r\nLocation: http://denied.test:{port}/next\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-        )
-        .unwrap();
+        );
+        stream.write_all(response.as_bytes()).unwrap();
     });
     let plan = runtime_plan(
         vec![
@@ -38,11 +37,10 @@ fn managed_proxy_revalidates_and_suppresses_a_denied_absolute_redirect() {
     .unwrap();
     let mut client = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "GET http://loop.test:{port}/start HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     let response = read_to_close(&mut client);
     assert!(response.is_empty());
@@ -92,11 +90,10 @@ fn managed_proxy_follows_relative_redirect_and_returns_only_final_response() {
     .unwrap();
     let mut client = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "GET http://loop.test:{port}/start HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     let response = String::from_utf8(read_to_close(&mut client)).unwrap();
     assert!(response.starts_with("HTTP/1.1 200 OK"));
@@ -114,11 +111,10 @@ fn managed_proxy_preserves_redirect_count_across_upstream_connections() {
         for next in ["/one", "/two"] {
             let (mut stream, _) = upstream.accept().unwrap();
             let _ = read_head(&mut stream);
-            write!(
-                stream,
+            let response = format!(
                 "HTTP/1.1 302 Found\r\nLocation: {next}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-            )
-            .unwrap();
+            );
+            stream.write_all(response.as_bytes()).unwrap();
         }
     });
     let plan = runtime_plan(
@@ -143,11 +139,10 @@ fn managed_proxy_preserves_redirect_count_across_upstream_connections() {
     .unwrap();
     let mut client = TcpStream::connect(proxy.endpoint().socket_addr()).unwrap();
     proxy.routing_token().expose_header(|token| {
-        write!(
-            client,
+        let request = format!(
             "GET http://loop.test:{port}/start HTTP/1.1\r\nHost: loop.test:{port}\r\nProxy-Authorization: Peritus {token}\r\n\r\n"
-        )
-        .unwrap();
+        );
+        client.write_all(request.as_bytes()).unwrap();
     });
     let response = read_to_close(&mut client);
     assert!(response.is_empty());

--- a/crates/runtime/peritus-process/src/bin/peritus-process-fixture/behavior.rs
+++ b/crates/runtime/peritus-process/src/bin/peritus-process-fixture/behavior.rs
@@ -123,5 +123,5 @@ fn pipe_holder() {
 }
 
 fn hold_open() {
-    thread::sleep(Duration::from_secs(5));
+    thread::sleep(Duration::from_secs(30));
 }

--- a/crates/runtime/peritus-process/tests/process_integration/regressions.rs
+++ b/crates/runtime/peritus-process/tests/process_integration/regressions.rs
@@ -61,7 +61,11 @@ fn root_exit_cleans_descendant_before_waiting_for_pipe_eof() {
     let began = Instant::now();
     let (owned, _) = launch(&root, &ids, execution);
     let terminal = owned.wait().expect("bounded descendant cleanup");
-    assert!(began.elapsed() < Duration::from_secs(3));
+    let elapsed = began.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "descendant cleanup exceeded its hosted-runner allowance: {elapsed:?}"
+    );
     assert!(terminal.tree_cleanup_complete());
     assert!(terminal.support_tasks_joined());
 }


### PR DESCRIPTION
## Summary
- buffer complete managed-proxy HTTP messages before a single write_all call
- retain the process cleanup ordering regression with hosted-runner scheduling allowance and a 30-second natural pipe-close control
- document both runner fixture repairs in the changelog

## Verification
- cargo fmt --all -- --check
- cargo test -p peritus-network --all-features
- cargo test -p peritus-process --all-features
- 10 consecutive complete peritus-network integration suite runs
- 20 consecutive process descendant-cleanup regression runs
- cargo clippy -p peritus-network -p peritus-process --all-targets --all-features -- -D warnings
- cargo build -p peritus-network -p peritus-process --all-targets --all-features
- git diff --check