### PR TITLE
fix(ci): bound macOS network tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build every target
         run: cargo build --workspace --all-targets --all-features --locked
       - name: Run tests
-        run: cargo test --workspace --all-targets --all-features --locked
+        run: cargo test --workspace --all-targets --all-features --locked -- --test-threads=1
       - name: Run documentation tests
         run: cargo test --doc --workspace --all-features --locked
       - name: Deny Clippy warnings

--- a/.github/workflows/formal-governance.yml
+++ b/.github/workflows/formal-governance.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Run tests
         if: matrix.operation == 'test'
         working-directory: candidate
-        run: cargo test --workspace --all-targets --all-features --locked
+        run: cargo test --workspace --all-targets --all-features --locked -- --test-threads=1
       - name: Run documentation tests
         if: matrix.operation == 'doc-test'
         working-directory: candidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Bound managed-network integration fixture accepts and reads, and serialize canonical test
+  execution per binary so a transient macOS socket stall fails promptly instead of exhausting a
+  hosted runner (#20)
+
 ### Added
 - Implement complete production E1 Harness Materialization (#20)
 - Deliver complete production E1 harness materialization as the H-class `peritus-harness` crate,

--- a/crates/runtime/peritus-network/tests/network.rs
+++ b/crates/runtime/peritus-network/tests/network.rs
@@ -47,7 +47,7 @@ fn managed_proxy_forwards_http_injects_scoped_credential_and_joins() {
     let upstream = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
-        let (mut stream, _) = upstream.accept().unwrap();
+        let mut stream = accept_with_timeout(&upstream);
         let head = read_head(&mut stream);
         assert!(head.contains("GET /value HTTP/1.1"));
         assert!(head.contains("Authorization: Bearer canary-value"));
@@ -110,7 +110,7 @@ fn managed_proxy_connect_tunnels_bidirectionally_and_joins_both_relays() {
     let upstream = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
-        let (mut stream, _) = upstream.accept().unwrap();
+        let mut stream = accept_with_timeout(&upstream);
         let mut request = [0_u8; 4];
         stream.read_exact(&mut request).unwrap();
         assert_eq!(&request, b"ping");
@@ -162,7 +162,7 @@ fn proxy_shutdown_cancels_an_active_connect_and_joins_the_worker() {
     let upstream = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
-        let (mut stream, _) = upstream.accept().unwrap();
+        let mut stream = accept_with_timeout(&upstream);
         stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
         let mut bytes = Vec::new();
         let _ = stream.read_to_end(&mut bytes);
@@ -209,7 +209,7 @@ fn worker_bound_applies_backpressure_and_shutdown_joins_the_active_tunnel() {
     let upstream = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
-        let (mut stream, _) = upstream.accept().unwrap();
+        let mut stream = accept_with_timeout(&upstream);
         stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
         let mut bytes = Vec::new();
         let _ = stream.read_to_end(&mut bytes);
@@ -294,7 +294,7 @@ fn connect_byte_ceiling_stops_the_tunnel_and_reports_a_limited_close() {
     let upstream = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
-        let (mut stream, _) = upstream.accept().unwrap();
+        let mut stream = accept_with_timeout(&upstream);
         let mut bytes = Vec::new();
         stream.read_to_end(&mut bytes).unwrap();
         assert!(bytes.is_empty());
@@ -331,8 +331,7 @@ fn connect_byte_ceiling_stops_the_tunnel_and_reports_a_limited_close() {
     assert!(read_head(&mut client).starts_with("HTTP/1.1 200"));
     let _ = client.write_all(b"ping");
     let _ = client.shutdown(Shutdown::Write);
-    let mut response = Vec::new();
-    let _ = client.read_to_end(&mut response);
+    let _ = read_to_close(&mut client);
     upstream_task.join().unwrap();
     wait_for_closed(&proxy, ConnectionDecision::Limited);
     assert!(proxy.shutdown().unwrap().workers_joined());

--- a/crates/runtime/peritus-network/tests/network/policy.rs
+++ b/crates/runtime/peritus-network/tests/network/policy.rs
@@ -89,7 +89,7 @@ fn inherited_listener_bridge_accepts_inside_namespace_and_connects_from_parent()
     let upstream = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let upstream_port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
-        let (mut stream, _) = upstream.accept().unwrap();
+        let mut stream = accept_with_timeout(&upstream);
         let _ = read_head(&mut stream);
         stream
             .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK")

--- a/crates/runtime/peritus-network/tests/network/redirects.rs
+++ b/crates/runtime/peritus-network/tests/network/redirects.rs
@@ -8,7 +8,7 @@ fn managed_proxy_revalidates_and_suppresses_a_denied_absolute_redirect() {
     let upstream = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
-        let (mut stream, _) = upstream.accept().unwrap();
+        let mut stream = accept_with_timeout(&upstream);
         let _ = read_head(&mut stream);
         let response = format!(
             "HTTP/1.1 302 Found\r\nLocation: http://denied.test:{port}/next\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
@@ -55,14 +55,14 @@ fn managed_proxy_follows_relative_redirect_and_returns_only_final_response() {
     let upstream = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
-        let (mut first, _) = upstream.accept().unwrap();
+        let mut first = accept_with_timeout(&upstream);
         assert!(read_head(&mut first).contains("GET /start HTTP/1.1"));
         first
             .write_all(
                 b"HTTP/1.1 302 Found\r\nLocation: /final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
             )
             .unwrap();
-        let (mut second, _) = upstream.accept().unwrap();
+        let mut second = accept_with_timeout(&upstream);
         assert!(read_head(&mut second).contains("GET /final HTTP/1.1"));
         // The checked connection budget, rather than a hidden sub-budget, governs
         // how long the proxy may wait for an admitted upstream response.
@@ -112,7 +112,7 @@ fn managed_proxy_preserves_redirect_count_across_upstream_connections() {
     let port = upstream.local_addr().unwrap().port();
     let upstream_task = thread::spawn(move || {
         for next in ["/one", "/two"] {
-            let (mut stream, _) = upstream.accept().unwrap();
+            let mut stream = accept_with_timeout(&upstream);
             let _ = read_head(&mut stream);
             let response = format!(
                 "HTTP/1.1 302 Found\r\nLocation: {next}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"

--- a/crates/runtime/peritus-network/tests/network/support.rs
+++ b/crates/runtime/peritus-network/tests/network/support.rs
@@ -4,6 +4,9 @@
 
 use super::*;
 
+const FIXTURE_IO_TIMEOUT: Duration = Duration::from_secs(10);
+const FIXTURE_ACCEPT_POLL: Duration = Duration::from_millis(5);
+
 pub struct LoopbackResolver;
 
 impl Resolver for LoopbackResolver {
@@ -104,11 +107,44 @@ pub fn wait_for_closed(proxy: &ManagedProxy, decision: ConnectionDecision) {
 }
 
 pub fn read_to_close(stream: &mut TcpStream) -> Vec<u8> {
+    if stream.read_timeout().unwrap().is_none() {
+        stream.set_read_timeout(Some(FIXTURE_IO_TIMEOUT)).unwrap();
+    }
     let mut bytes = Vec::new();
-    if let Err(error) = stream.read_to_end(&mut bytes) {
-        assert_eq!(error.kind(), ErrorKind::ConnectionReset);
+    match stream.read_to_end(&mut bytes) {
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::ConnectionReset => {}
+        Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+            panic!("network fixture did not close within {FIXTURE_IO_TIMEOUT:?}")
+        }
+        Err(error) => panic!("network fixture read failed: {error}"),
     }
     bytes
+}
+
+pub fn accept_with_timeout(listener: &TcpListener) -> TcpStream {
+    listener.set_nonblocking(true).unwrap();
+    let deadline = std::time::Instant::now() + FIXTURE_IO_TIMEOUT;
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                listener.set_nonblocking(false).unwrap();
+                stream.set_read_timeout(Some(FIXTURE_IO_TIMEOUT)).unwrap();
+                stream.set_write_timeout(Some(FIXTURE_IO_TIMEOUT)).unwrap();
+                return stream;
+            }
+            Err(error)
+                if error.kind() == ErrorKind::WouldBlock
+                    && std::time::Instant::now() < deadline =>
+            {
+                thread::sleep(FIXTURE_ACCEPT_POLL);
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                panic!("network fixture did not accept a connection within {FIXTURE_IO_TIMEOUT:?}")
+            }
+            Err(error) => panic!("network fixture accept failed: {error}"),
+        }
+    }
 }
 
 pub fn serial_proxy_test() -> std::sync::MutexGuard<'static, ()> {

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ build:
     cargo build --workspace --all-targets --all-features --locked
 
 test:
-    cargo test --workspace --all-targets --all-features --locked
+    cargo test --workspace --all-targets --all-features --locked -- --test-threads=1
 
 doc-test:
     cargo test --doc --workspace --all-features --locked

--- a/xtask/src/reproducibility/just_policy.rs
+++ b/xtask/src/reproducibility/just_policy.rs
@@ -3,7 +3,7 @@ use super::verus_commands::{
     VERUS_WORKSPACE_VERIFY_ARGS,
 };
 use super::workflow_command_policy;
-use super::workflow_commands::{CommandPolicy, parse_script};
+use super::workflow_commands::{CommandPolicy, WORKSPACE_TEST_ARGS, parse_script};
 use crate::error::{Diagnostic, XtaskError};
 use std::collections::BTreeMap;
 use std::fs;
@@ -81,7 +81,7 @@ fn validate_recipe_contract(recipes: &BTreeMap<String, Recipe>, diagnostics: &mu
     for (name, operation) in [
         ("fmt", &["fmt", "--all", "--", "--check"][..]),
         ("build", &["build", "--workspace", "--all-targets", "--all-features", "--locked"][..]),
-        ("test", &["test", "--workspace", "--all-targets", "--all-features", "--locked"][..]),
+        ("test", WORKSPACE_TEST_ARGS),
         ("doc-test", &["test", "--doc", "--workspace", "--all-features", "--locked"][..]),
         (
             "clippy",

--- a/xtask/src/reproducibility/reproducibility_ci_control_tests.rs
+++ b/xtask/src/reproducibility/reproducibility_ci_control_tests.rs
@@ -129,8 +129,8 @@ fn workflow_root_controls_are_exact_and_automatic() {
 fn ci_cargo_steps_reject_wrapper_and_path_assignments() {
     for (needle, replacement) in [
         (
-            "run: cargo test --workspace --all-targets --all-features --locked",
-            "run: RUSTC_WRAPPER=./evil cargo test --workspace --all-targets --all-features --locked",
+            "run: cargo test --workspace --all-targets --all-features --locked -- --test-threads=1",
+            "run: RUSTC_WRAPPER=./evil cargo test --workspace --all-targets --all-features --locked -- --test-threads=1",
         ),
         ("run: cargo deny --locked check", "run: PATH=./attacker cargo deny --locked check"),
     ] {

--- a/xtask/src/reproducibility/reproducibility_just_tests.rs
+++ b/xtask/src/reproducibility/reproducibility_just_tests.rs
@@ -10,7 +10,7 @@ fmt:
 build:
     cargo build --workspace --all-targets --all-features --locked
 test:
-    cargo test --workspace --all-targets --all-features --locked
+    cargo test --workspace --all-targets --all-features --locked -- --test-threads=1
 doc-test:
     cargo test --doc --workspace --all-features --locked
 clippy:
@@ -71,7 +71,7 @@ fn ignored_failure_sigil_and_partial_deny_are_rejected() {
 #[test]
 fn multiline_commands_are_validated_after_joining() {
     let altered = CANONICAL.replace(
-        "cargo test --workspace --all-targets --all-features --locked",
+        "cargo test --workspace --all-targets --all-features --locked -- --test-threads=1",
         "cargo test --workspace \\\n+      --all-targets --all-features",
     );
     let diagnostics = validate(&altered);
@@ -120,8 +120,8 @@ fn just_rejects_wrapper_and_path_assignments_but_retains_exact_docs_flags() {
             "RUSTC_WRAPPER=./evil cargo build --workspace --all-targets --all-features --locked",
         ),
         CANONICAL.replace(
-            "cargo test --workspace --all-targets --all-features --locked",
-            "PATH=./attacker cargo test --workspace --all-targets --all-features --locked",
+            "cargo test --workspace --all-targets --all-features --locked -- --test-threads=1",
+            "PATH=./attacker cargo test --workspace --all-targets --all-features --locked -- --test-threads=1",
         ),
     ] {
         assert_ne!(altered, CANONICAL, "fixture mutation must apply");

--- a/xtask/src/reproducibility/workflow_ci.rs
+++ b/xtask/src/reproducibility/workflow_ci.rs
@@ -4,7 +4,7 @@ use super::verus_commands::{
     VERUS_STRICT_BUILD_ARGS, VERUS_STRICT_VERIFY_ARGS, VERUS_WORKSPACE_BUILD_ARGS,
     VERUS_WORKSPACE_VERIFY_ARGS,
 };
-use super::workflow_commands::{ParsedScript, parse_script};
+use super::workflow_commands::{ParsedScript, WORKSPACE_TEST_ARGS, parse_script};
 use crate::error::Diagnostic;
 use crate::model::ToolchainPolicy;
 use std::path::Path;
@@ -147,10 +147,7 @@ fn rust_job_is_exact(job: &Yaml) -> bool {
                     &steps[3],
                     &["build", "--workspace", "--all-targets", "--all-features", "--locked"],
                 )
-                && cargo_step(
-                    &steps[4],
-                    &["test", "--workspace", "--all-targets", "--all-features", "--locked"],
-                )
+                && cargo_step(&steps[4], WORKSPACE_TEST_ARGS)
                 && cargo_step(
                     &steps[5],
                     &["test", "--doc", "--workspace", "--all-features", "--locked"],

--- a/xtask/src/reproducibility/workflow_commands.rs
+++ b/xtask/src/reproducibility/workflow_commands.rs
@@ -6,6 +6,15 @@ use super::workflow_command_syntax::{
 };
 
 const PRE_CARGO_AUTHORITY: &str = "6ca5f56d2ab12e93f155d684b33f4a86c2f877b8";
+pub(super) const WORKSPACE_TEST_ARGS: &[&str] = &[
+    "test",
+    "--workspace",
+    "--all-targets",
+    "--all-features",
+    "--locked",
+    "--",
+    "--test-threads=1",
+];
 
 #[derive(Clone, Copy)]
 pub(super) struct CommandPolicy {

--- a/xtask/src/reproducibility/workflow_governance_jobs.rs
+++ b/xtask/src/reproducibility/workflow_governance_jobs.rs
@@ -3,7 +3,7 @@ use super::verus_commands::{
     VERUS_WORKSPACE_VERIFY_ARGS,
 };
 use super::workflow_actionlint;
-use super::workflow_commands::{ParsedScript, parse_script};
+use super::workflow_commands::{ParsedScript, WORKSPACE_TEST_ARGS, parse_script};
 use super::workflow_governance::{
     candidate_checkout, config_step, exact_keys, integer, mapping_value, rust_step, string,
 };
@@ -71,11 +71,7 @@ fn rust_gate_is_exact(job: &Yaml) -> bool {
                     "matrix.operation == 'build'",
                     &["build", "--workspace", "--all-targets", "--all-features", "--locked"],
                 )
-                && conditional_cargo(
-                    &steps[5],
-                    "matrix.operation == 'test'",
-                    &["test", "--workspace", "--all-targets", "--all-features", "--locked"],
-                )
+                && conditional_cargo(&steps[5], "matrix.operation == 'test'", WORKSPACE_TEST_ARGS)
                 && conditional_cargo(
                     &steps[6],
                     "matrix.operation == 'doc-test'",


### PR DESCRIPTION
## Summary
- bound managed-network fixture accepts and reads to turn socket stalls into prompt, attributable failures
- run canonical workspace tests with one libtest thread per binary across local and hosted Gate A/Foundation paths
- keep exact workflow/just policy checks and changelog aligned

## Verification
- `CARGO_BUILD_JOBS=1 cargo test --locked --package peritus-network --all-targets --all-features -- --test-threads=1`
- managed-network integration suite passed three consecutive `--test-threads=8` stress runs
- `CARGO_BUILD_JOBS=1 cargo clippy --locked --package peritus-network --package xtask --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo test --locked --package xtask reproducibility` (87 passed)
- `CARGO_BUILD_JOBS=1 cargo run --locked --package xtask -- all`
- `CARGO_BUILD_JOBS=1 cargo fmt --all -- --check`
- `git diff --check`

The previously completed single full local Gate A remains the only full local Gate A run for E1.