### PR TITLE
fix(c5): qualify live account runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
+- Keep Codex Code Mode disabled without disabling its inert host feature, avoiding the current CLI
+  0.149.1 nonfatal host-unavailable event that the account-runtime decoder correctly rejects
 - Give native plugin test fixtures a runner-safe process-startup allowance while preserving the
   stricter invocation, cancellation, and shutdown deadlines they are intended to verify (#27)
 - Format each workspace package independently on Windows hosted runners so Rustfmt stays below the
@@ -21,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   hosted runner (#20)
 
 ### Added
+- Add retained credentialed Codex and Claude account-route qualification examples that exercise
+  the production Peritus adapters and require contiguous events, usage, exact canaries, no native
+  tool activity, and successful normalized terminals
 - Complete the H0/H4 final production-qualification implementation wave (#31)
 - Add the V-class `peritus-security-policy` crate with literal R-SEC-001 through R-SEC-007 and
   security-relevant acceptance-criterion catalogs, exact integrated-candidate freshness,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,12 +2589,17 @@ dependencies = [
 name = "peritus-release-qualification"
 version = "0.0.0"
 dependencies = [
+ "peritus-model-protocol",
+ "peritus-provider-anthropic",
+ "peritus-provider-core",
+ "peritus-provider-openai",
  "peritus-release-artifacts",
  "peritus-release-policy",
  "peritus-types",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+ "tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ just verus-build    # full verified release plus no-cheating V/H builds
 just gate-a         # the complete formal-foundation gate
 ```
 
+Credentialed C5 qualification is explicit because hosted and ordinary local gates never receive
+provider accounts. After authenticating the official executables, run the retained
+`peritus-release-qualification` live-account examples documented in the owning provider crate
+READMEs. Each probe exercises the production Peritus adapter and requires normalized
+usage, exact canary text, no native-tool activity, and a completed terminal.
+
 All dependency-resolving commands use `--locked`. `architecture.toml` is the reviewed registry
 for crate ownership, dependency layers, verification classes, trusted source roots, and source
 size exceptions. New crates must inherit the workspace package metadata and lints, declare their

--- a/crates/app/testing/peritus-release-qualification/Cargo.toml
+++ b/crates/app/testing/peritus-release-qualification/Cargo.toml
@@ -19,7 +19,22 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+peritus-model-protocol = { version = "=0.0.0", path = "../../../model/peritus-model-protocol" }
+peritus-provider-anthropic = { version = "=0.0.0", path = "../../../model/peritus-provider-anthropic" }
+peritus-provider-core = { version = "=0.0.0", path = "../../../model/peritus-provider-core" }
+peritus-provider-openai = { version = "=0.0.0", path = "../../../model/peritus-provider-openai" }
 peritus-types = { version = "=0.0.0", path = "../../../foundation/peritus-types" }
+tokio.workspace = true
+
+[[example]]
+name = "codex-live-account"
+path = "examples/codex_live_account.rs"
+test = false
+
+[[example]]
+name = "claude-live-account"
+path = "examples/claude_live_account.rs"
+test = false
 
 [package.metadata.peritus]
 owner = "H4"

--- a/crates/app/testing/peritus-release-qualification/examples/claude_live_account.rs
+++ b/crates/app/testing/peritus-release-qualification/examples/claude_live_account.rs
@@ -1,0 +1,147 @@
+//! Credentialed one-turn qualification for the Claude account runtime.
+
+use std::error::Error;
+use std::io;
+use std::time::Duration;
+
+use peritus_model_protocol::{
+    BoundedText, CachePolicy, CancellationKind, Capability, CapabilityMatrix, CapabilityProvenance,
+    ContentBlock, GenerationConfig, Message, ModelEvent, ModelLimits, ModelName, ModelRequest,
+    OutputLimitEnforcement, ParallelToolPolicy, PersistencePolicy, ProtocolLimits, ProviderName,
+    ProviderProfile, ReasoningPolicy, RequestId, RequestOptions, RequestedCapabilities, ResumeKind,
+    Role, StateMode, StructuredOutput, ToolChoice, WireDialect, negotiate,
+};
+use peritus_provider_anthropic::{ClaudeExecutable, ClaudeRuntimeConfig, ClaudeRuntimeProvider};
+use peritus_provider_core::{CancellationToken, ModelProvider, ProcessLimits};
+use peritus_types::ProviderProfileId;
+
+const CANARY: &str = "PERITUS_CLAUDE_ACCOUNT_ROUTE_OK";
+const DEFAULT_MODEL: &str = "sonnet";
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let model = std::env::args().nth(1).unwrap_or_else(|| DEFAULT_MODEL.to_owned());
+    let profile = profile(&model)?;
+    let request = request(&profile)?;
+    let executable = ClaudeExecutable::discover()?;
+    let process_limits =
+        ProcessLimits::new(16 * 1024 * 1024, 16 * 1024 * 1024, 64 * 1024, Duration::from_mins(3))?;
+    let provider =
+        ClaudeRuntimeProvider::new(ClaudeRuntimeConfig::new(executable, profile, process_limits)?);
+    let cancellation = CancellationToken::new();
+
+    provider.require_authenticated(&cancellation).await?;
+    let mut stream = provider.start(request, cancellation).await?;
+    let mut text = Vec::new();
+    let mut events = 0_u64;
+    let mut usage_observed = false;
+    let mut completed = false;
+
+    while let Some(envelope) = stream.pull().await? {
+        events = events.checked_add(1).ok_or_else(|| io::Error::other("event count overflow"))?;
+        if envelope.sequence() != events {
+            return Err(io::Error::other("adapter emitted a non-contiguous sequence").into());
+        }
+        match envelope.event() {
+            ModelEvent::TextDelta { fragment, .. } => text.extend_from_slice(fragment.expose()),
+            ModelEvent::Usage(_) => usage_observed = true,
+            ModelEvent::ToolCallStarted { .. } | ModelEvent::ToolArgumentDelta { .. } => {
+                return Err(io::Error::other("tool activity escaped a tool-free request").into());
+            }
+            ModelEvent::ResponseCompleted => completed = true,
+            ModelEvent::ResponseFailed(failure) => {
+                return Err(io::Error::other(format!(
+                    "Claude account runtime returned a normalized failure: {failure:?}"
+                ))
+                .into());
+            }
+            ModelEvent::ResponseCancelled => {
+                return Err(io::Error::other("Claude account runtime was cancelled").into());
+            }
+            _ => {}
+        }
+    }
+
+    if !completed || !stream.terminal_observed() {
+        return Err(io::Error::other("Claude account runtime did not complete").into());
+    }
+    if !usage_observed {
+        return Err(io::Error::other("Claude account runtime omitted required usage").into());
+    }
+    let text = String::from_utf8(text)?;
+    if text.trim() != CANARY {
+        return Err(io::Error::other("Claude account runtime returned unexpected text").into());
+    }
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "provider": "anthropic-claude-account",
+            "model": model,
+            "events": events,
+            "usage_observed": true,
+            "terminal": "completed",
+            "canary": "matched",
+        })
+    );
+    Ok(())
+}
+
+fn profile(model: &str) -> Result<ProviderProfile, Box<dyn Error>> {
+    Ok(ProviderProfile::new(
+        ProviderProfileId::new([0xB6; 16])
+            .map_err(|_| io::Error::other("provider profile identity is invalid"))?,
+        1,
+        ProviderName::new("anthropic".to_owned())?,
+        ModelName::new(model.to_owned())?,
+        WireDialect::AnthropicClaudeRuntime,
+        CapabilityMatrix::new(
+            &[Capability::ToolCalls, Capability::ParallelToolCalls, Capability::UsageDetail],
+            &[],
+        )?,
+        CapabilityProvenance::Profiled,
+        ModelLimits::new(200_000, 32_000, 32, 8, 1)?,
+        OutputLimitEnforcement::Advisory,
+        StateMode::StatelessReplay,
+        ResumeKind::Unsupported,
+        CancellationKind::BestEffortLocalAbort,
+    )?)
+}
+
+fn request(profile: &ProviderProfile) -> Result<ModelRequest, Box<dyn Error>> {
+    let negotiated = negotiate(
+        profile,
+        RequestedCapabilities::new(&[Capability::UsageDetail], &[], profile.limits())?,
+    )?;
+    let messages = vec![
+        message(Role::System, "Return the user's requested text exactly, with no decoration.")?,
+        message(Role::User, &format!("Return exactly {CANARY} and nothing else."))?,
+    ];
+    Ok(ModelRequest::new(
+        profile,
+        negotiated,
+        RequestId::new("live-claude-account-qualification".to_owned())?,
+        messages,
+        Vec::new(),
+        ToolChoice::None,
+        ParallelToolPolicy::Disabled,
+        RequestOptions::new(
+            StructuredOutput::Text,
+            ReasoningPolicy::Disabled,
+            GenerationConfig::new(64, Vec::new(), None, None, None)?,
+            CachePolicy::Disabled,
+            PersistencePolicy::LOCAL_FIRST,
+            None,
+            Vec::new(),
+        ),
+        ProtocolLimits::PRODUCTION,
+    )?)
+}
+
+fn message(role: Role, text: &str) -> Result<Message, Box<dyn Error>> {
+    Ok(Message::new(
+        role,
+        vec![ContentBlock::Text(BoundedText::new(text.to_owned(), ProtocolLimits::PRODUCTION)?)],
+        ProtocolLimits::PRODUCTION,
+    )?)
+}

--- a/crates/app/testing/peritus-release-qualification/examples/codex_live_account.rs
+++ b/crates/app/testing/peritus-release-qualification/examples/codex_live_account.rs
@@ -1,0 +1,147 @@
+//! Credentialed one-turn qualification for the Codex account runtime.
+
+use std::error::Error;
+use std::io;
+use std::time::Duration;
+
+use peritus_model_protocol::{
+    BoundedText, CachePolicy, CancellationKind, Capability, CapabilityMatrix, CapabilityProvenance,
+    ContentBlock, GenerationConfig, Message, ModelEvent, ModelLimits, ModelName, ModelRequest,
+    OutputLimitEnforcement, ParallelToolPolicy, PersistencePolicy, ProtocolLimits, ProviderName,
+    ProviderProfile, ReasoningPolicy, RequestId, RequestOptions, RequestedCapabilities, ResumeKind,
+    Role, StateMode, StructuredOutput, ToolChoice, WireDialect, negotiate,
+};
+use peritus_provider_core::{CancellationToken, ModelProvider, ProcessLimits};
+use peritus_provider_openai::{CodexExecutable, CodexRuntimeConfig, CodexRuntimeProvider};
+use peritus_types::ProviderProfileId;
+
+const CANARY: &str = "PERITUS_CODEX_ACCOUNT_ROUTE_OK";
+const DEFAULT_MODEL: &str = "gpt-5.6-sol";
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let model = std::env::args().nth(1).unwrap_or_else(|| DEFAULT_MODEL.to_owned());
+    let profile = profile(&model)?;
+    let request = request(&profile)?;
+    let executable = CodexExecutable::discover()?;
+    let process_limits =
+        ProcessLimits::new(2 * 1024 * 1024, 2 * 1024 * 1024, 64 * 1024, Duration::from_mins(3))?;
+    let provider =
+        CodexRuntimeProvider::new(CodexRuntimeConfig::new(executable, profile, process_limits)?);
+    let cancellation = CancellationToken::new();
+
+    provider.require_authenticated(&cancellation).await?;
+    let mut stream = provider.start(request, cancellation).await?;
+    let mut text = Vec::new();
+    let mut events = 0_u64;
+    let mut usage_observed = false;
+    let mut completed = false;
+
+    while let Some(envelope) = stream.pull().await? {
+        events = events.checked_add(1).ok_or_else(|| io::Error::other("event count overflow"))?;
+        if envelope.sequence() != events {
+            return Err(io::Error::other("adapter emitted a non-contiguous sequence").into());
+        }
+        match envelope.event() {
+            ModelEvent::TextDelta { fragment, .. } => text.extend_from_slice(fragment.expose()),
+            ModelEvent::Usage(_) => usage_observed = true,
+            ModelEvent::ToolCallStarted { .. } | ModelEvent::ToolArgumentDelta { .. } => {
+                return Err(io::Error::other("tool activity escaped a tool-free request").into());
+            }
+            ModelEvent::ResponseCompleted => completed = true,
+            ModelEvent::ResponseFailed(failure) => {
+                return Err(io::Error::other(format!(
+                    "Codex account runtime returned a normalized failure: {failure:?}"
+                ))
+                .into());
+            }
+            ModelEvent::ResponseCancelled => {
+                return Err(io::Error::other("Codex account runtime was cancelled").into());
+            }
+            _ => {}
+        }
+    }
+
+    if !completed || !stream.terminal_observed() {
+        return Err(io::Error::other("Codex account runtime did not complete").into());
+    }
+    if !usage_observed {
+        return Err(io::Error::other("Codex account runtime omitted required usage").into());
+    }
+    let text = String::from_utf8(text)?;
+    if text.trim() != CANARY {
+        return Err(io::Error::other("Codex account runtime returned unexpected text").into());
+    }
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "provider": "openai-codex-account",
+            "model": model,
+            "events": events,
+            "usage_observed": true,
+            "terminal": "completed",
+            "canary": "matched",
+        })
+    );
+    Ok(())
+}
+
+fn profile(model: &str) -> Result<ProviderProfile, Box<dyn Error>> {
+    Ok(ProviderProfile::new(
+        ProviderProfileId::new([0xA5; 16])
+            .map_err(|_| io::Error::other("provider profile identity is invalid"))?,
+        1,
+        ProviderName::new("openai".to_owned())?,
+        ModelName::new(model.to_owned())?,
+        WireDialect::OpenAiCodexRuntime,
+        CapabilityMatrix::new(
+            &[Capability::ToolCalls, Capability::ParallelToolCalls, Capability::UsageDetail],
+            &[],
+        )?,
+        CapabilityProvenance::Profiled,
+        ModelLimits::new(200_000, 32_000, 32, 8, 1)?,
+        OutputLimitEnforcement::Advisory,
+        StateMode::StatelessReplay,
+        ResumeKind::Unsupported,
+        CancellationKind::BestEffortLocalAbort,
+    )?)
+}
+
+fn request(profile: &ProviderProfile) -> Result<ModelRequest, Box<dyn Error>> {
+    let negotiated = negotiate(
+        profile,
+        RequestedCapabilities::new(&[Capability::UsageDetail], &[], profile.limits())?,
+    )?;
+    let messages = vec![
+        message(Role::System, "Return the user's requested text exactly, with no decoration.")?,
+        message(Role::User, &format!("Return exactly {CANARY} and nothing else."))?,
+    ];
+    Ok(ModelRequest::new(
+        profile,
+        negotiated,
+        RequestId::new("live-codex-account-qualification".to_owned())?,
+        messages,
+        Vec::new(),
+        ToolChoice::None,
+        ParallelToolPolicy::Disabled,
+        RequestOptions::new(
+            StructuredOutput::Text,
+            ReasoningPolicy::Disabled,
+            GenerationConfig::new(64, Vec::new(), None, None, None)?,
+            CachePolicy::Disabled,
+            PersistencePolicy::LOCAL_FIRST,
+            None,
+            Vec::new(),
+        ),
+        ProtocolLimits::PRODUCTION,
+    )?)
+}
+
+fn message(role: Role, text: &str) -> Result<Message, Box<dyn Error>> {
+    Ok(Message::new(
+        role,
+        vec![ContentBlock::Text(BoundedText::new(text.to_owned(), ProtocolLimits::PRODUCTION)?)],
+        ProtocolLimits::PRODUCTION,
+    )?)
+}

--- a/crates/model/peritus-provider-anthropic/README.md
+++ b/crates/model/peritus-provider-anthropic/README.md
@@ -65,6 +65,20 @@ provider-core planner with test-only explicit rejected rate/transient fixtures: 
 delay drive two real process turns. This proves planner/process composition without claiming that
 production Claude errors can be classified from undocumented or untrusted result text.
 
+### Live account qualification
+
+After `claude auth status` confirms an authenticated official CLI, run the retained credentialed
+probe from the repository root:
+
+```text
+CARGO_BUILD_JOBS=1 cargo run --locked --package peritus-release-qualification --example claude-live-account --all-features
+```
+
+An optional final argument overrides the default `sonnet` model. The probe goes through
+`ClaudeRuntimeProvider`, not a direct CLI shortcut. It requires contiguous normalized events,
+usage, an exact fixed canary, no tool activity, and a completed terminal. The command consumes
+account usage and is intentionally not executed by credential-free Gate A.
+
 ## Fixtures and qualification
 
 `fixtures/v1/MANIFEST` records the official contract sources and corpus purpose. `SHA256SUMS`

--- a/crates/model/peritus-provider-openai/README.md
+++ b/crates/model/peritus-provider-openai/README.md
@@ -72,6 +72,20 @@ is partial or ambiguous according to observed JSONL, and the adapter never autom
 turn. Codex CLI error text is redacted and generic; the runtime does not speculate that undocumented
 CLI error codes provide rate-limit or transient classifications.
 
+### Live account qualification
+
+After `codex login status` confirms an authenticated official CLI, run the retained credentialed
+probe from the repository root:
+
+```text
+CARGO_BUILD_JOBS=1 cargo run --locked --package peritus-release-qualification --example codex-live-account --all-features
+```
+
+An optional final argument overrides the default `gpt-5.6-sol` model. The probe goes through
+`CodexRuntimeProvider`, not a direct CLI shortcut. It requires contiguous normalized events,
+usage, an exact fixed canary, no tool activity, and a completed terminal. The command consumes
+account usage and is intentionally not executed by credential-free Gate A.
+
 ## Compatibility corpus
 
 `fixtures/v1` is the immutable official-contract corpus for this adapter revision. `MANIFEST`

--- a/crates/model/peritus-provider-openai/src/bin/codex_runtime_fake/contract.rs
+++ b/crates/model/peritus-provider-openai/src/bin/codex_runtime_fake/contract.rs
@@ -24,7 +24,8 @@ pub(super) fn valid(arguments: &[String], stdin: &str) -> bool {
     required_present
         && environment_absent()
         && isolated_schema
-        && arguments.iter().filter(|value| value.as_str() == "--disable").count() >= 16
+        && arguments.iter().filter(|value| value.as_str() == "--disable").count() == 15
+        && !arguments.iter().any(|value| value == "code_mode_host")
         && stdin.starts_with("Peritus is the sole host agent")
 }
 

--- a/crates/model/peritus-provider-openai/src/runtime/provider/invocation.rs
+++ b/crates/model/peritus-provider-openai/src/runtime/provider/invocation.rs
@@ -29,7 +29,6 @@ const DISABLED_NATIVE_FEATURES: &[&str] = &[
     "tool_call_mcp_elicitation",
     "request_permissions_tool",
     "code_mode",
-    "code_mode_host",
 ];
 
 pub(super) fn require_authenticated<'a>(

--- a/docs/c5-model-providers.md
+++ b/docs/c5-model-providers.md
@@ -263,6 +263,13 @@ bodies and deliberate closure, exposes synchronization points for cancellation, 
 allowlisted digests/counts, and joins all workers on drop. Required tests make no live network calls
 and require no provider credentials.
 
+Credentialed account-route qualification is retained as one live-account example in each owning
+provider crate. The examples call `CodexRuntimeProvider` and `ClaudeRuntimeProvider` directly,
+require authentication through the official executables, and fail unless event sequences are
+contiguous, usage is observed, native tool activity is absent, exact fixed canary text is returned,
+and the normalized terminal is successful. They consume account usage and therefore remain
+explicit operator commands rather than part of credential-free Gate A.
+
 The Verus functional core covers capability intersection, request bounds, reducer lifecycle and
 terminal uniqueness, exact deduplication, fragment completion, monotonic usage, retry legality, and
 the fact that provider observations cannot grant authority or budget. TLS, HTTP, async wakeups,


### PR DESCRIPTION
## Outcome

Retains explicit credentialed Codex and Claude account-route qualification through the production Peritus adapters and repairs Codex CLI 0.149.1 compatibility while keeping native Code Mode disabled.

## Evidence

- Codex `gpt-5.6-sol`: 7 contiguous events, usage observed, exact canary, no tool activity, completed terminal
- Claude `sonnet`: 7 contiguous events, usage observed, exact canary, no tool activity, completed terminal
- `just gate-a` passed with `CARGO_BUILD_JOBS=1`, including workspace tests, strict Clippy/rustdoc, dependency policy, full Verus verification, and verified release builds
- Focused release-qualification tests: 6 passed, 0 failed, 0 ignored
- Signed commit: `b4e9730a2409691cf84e12c81f15542a035f684e`

Credentialed probes remain explicit operator commands and are not added to credential-free hosted gates.