### PR TITLE
fix(ci): bound native preparation with per-binary builds

### DIFF
--- a/.github/workflows/product-package.yml
+++ b/.github/workflows/product-package.yml
@@ -51,18 +51,56 @@ jobs:
       - name: Qualify native package and public installer lifecycle
         run: cargo run --locked --package xtask -- release-bootstrap-prepared-smoke
 
-  prepare-h2:
-    name: Prepare H2 package (${{ matrix.os }})
+  build-h2-binary:
+    name: Build H2 binary ${{ matrix.binary }} (${{ matrix.os }})
+    env:
+      CARGO_BUILD_JOBS: "2"
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-24.04, helper: peritus-sandbox-linux }
-          - { os: ubuntu-24.04-arm, helper: peritus-sandbox-linux }
-          - { os: macos-15, helper: peritus-sandbox-macos }
-          - { os: macos-15-intel, helper: peritus-sandbox-macos }
-          - { os: windows-2025, helper: peritus-sandbox-windows }
-          - { os: windows-11-arm, helper: peritus-sandbox-windows }
+          - { os: ubuntu-24.04, package: peritus-cli, binary: peritus, artifact: peritus }
+          - { os: ubuntu-24.04, package: peritus-daemon, binary: peritusd, artifact: peritusd }
+          - { os: ubuntu-24.04, package: peritus-tui, binary: peritus-tui, artifact: peritus-tui }
+          - { os: ubuntu-24.04, package: peritus-sandbox-linux, binary: peritus-linux-sandbox-helper, artifact: peritus-linux-sandbox-helper }
+          - { os: ubuntu-24.04, package: peritus-platform-qualification, binary: peritus-package, artifact: peritus-package }
+          - { os: ubuntu-24.04, package: peritus-platform-qualification, binary: peritus-h2, artifact: peritus-h2 }
+          - { os: ubuntu-24.04, package: peritus-platform-qualification, binary: peritus-h2-controller, artifact: peritus-h2-controller }
+          - { os: ubuntu-24.04-arm, package: peritus-cli, binary: peritus, artifact: peritus }
+          - { os: ubuntu-24.04-arm, package: peritus-daemon, binary: peritusd, artifact: peritusd }
+          - { os: ubuntu-24.04-arm, package: peritus-tui, binary: peritus-tui, artifact: peritus-tui }
+          - { os: ubuntu-24.04-arm, package: peritus-sandbox-linux, binary: peritus-linux-sandbox-helper, artifact: peritus-linux-sandbox-helper }
+          - { os: ubuntu-24.04-arm, package: peritus-platform-qualification, binary: peritus-package, artifact: peritus-package }
+          - { os: ubuntu-24.04-arm, package: peritus-platform-qualification, binary: peritus-h2, artifact: peritus-h2 }
+          - { os: ubuntu-24.04-arm, package: peritus-platform-qualification, binary: peritus-h2-controller, artifact: peritus-h2-controller }
+          - { os: macos-15, package: peritus-cli, binary: peritus, artifact: peritus }
+          - { os: macos-15, package: peritus-daemon, binary: peritusd, artifact: peritusd }
+          - { os: macos-15, package: peritus-tui, binary: peritus-tui, artifact: peritus-tui }
+          - { os: macos-15, package: peritus-sandbox-macos, binary: peritus-macos-sandbox-helper, artifact: peritus-macos-sandbox-helper }
+          - { os: macos-15, package: peritus-platform-qualification, binary: peritus-package, artifact: peritus-package }
+          - { os: macos-15, package: peritus-platform-qualification, binary: peritus-h2, artifact: peritus-h2 }
+          - { os: macos-15, package: peritus-platform-qualification, binary: peritus-h2-controller, artifact: peritus-h2-controller }
+          - { os: macos-15-intel, package: peritus-cli, binary: peritus, artifact: peritus }
+          - { os: macos-15-intel, package: peritus-daemon, binary: peritusd, artifact: peritusd }
+          - { os: macos-15-intel, package: peritus-tui, binary: peritus-tui, artifact: peritus-tui }
+          - { os: macos-15-intel, package: peritus-sandbox-macos, binary: peritus-macos-sandbox-helper, artifact: peritus-macos-sandbox-helper }
+          - { os: macos-15-intel, package: peritus-platform-qualification, binary: peritus-package, artifact: peritus-package }
+          - { os: macos-15-intel, package: peritus-platform-qualification, binary: peritus-h2, artifact: peritus-h2 }
+          - { os: macos-15-intel, package: peritus-platform-qualification, binary: peritus-h2-controller, artifact: peritus-h2-controller }
+          - { os: windows-2025, package: peritus-cli, binary: peritus, artifact: peritus.exe }
+          - { os: windows-2025, package: peritus-daemon, binary: peritusd, artifact: peritusd.exe }
+          - { os: windows-2025, package: peritus-tui, binary: peritus-tui, artifact: peritus-tui.exe }
+          - { os: windows-2025, package: peritus-sandbox-windows, binary: peritus-windows-sandbox-helper, artifact: peritus-windows-sandbox-helper.exe }
+          - { os: windows-2025, package: peritus-platform-qualification, binary: peritus-package, artifact: peritus-package.exe }
+          - { os: windows-2025, package: peritus-platform-qualification, binary: peritus-h2, artifact: peritus-h2.exe }
+          - { os: windows-2025, package: peritus-platform-qualification, binary: peritus-h2-controller, artifact: peritus-h2-controller.exe }
+          - { os: windows-11-arm, package: peritus-cli, binary: peritus, artifact: peritus.exe }
+          - { os: windows-11-arm, package: peritus-daemon, binary: peritusd, artifact: peritusd.exe }
+          - { os: windows-11-arm, package: peritus-tui, binary: peritus-tui, artifact: peritus-tui.exe }
+          - { os: windows-11-arm, package: peritus-sandbox-windows, binary: peritus-windows-sandbox-helper, artifact: peritus-windows-sandbox-helper.exe }
+          - { os: windows-11-arm, package: peritus-platform-qualification, binary: peritus-package, artifact: peritus-package.exe }
+          - { os: windows-11-arm, package: peritus-platform-qualification, binary: peritus-h2, artifact: peritus-h2.exe }
+          - { os: windows-11-arm, package: peritus-platform-qualification, binary: peritus-h2-controller, artifact: peritus-h2-controller.exe }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
@@ -74,12 +112,41 @@ jobs:
           RUSTUP_MAX_RETRIES: "10"
         with:
           toolchain: ${{ env.RUST_VERSION }}
-      - name: Build native application and qualification tools once
-        env:
-          CARGO_BUILD_JOBS: "2"
+      - name: Build one native binary
         run: >-
-          cargo build --locked --bins -p xtask -p peritus-cli -p peritus-daemon
-          -p peritus-tui -p peritus-platform-qualification -p ${{ matrix.helper }}
+          cargo build --locked --package ${{ matrix.package }} --bin ${{ matrix.binary }}
+      - name: Retain one same-run native binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: h2-bin-${{ matrix.os }}--${{ matrix.binary }}
+          path: target/debug/${{ matrix.artifact }}
+          if-no-files-found: error
+          retention-days: 7
+
+  prepare-h2:
+    name: Prepare H2 package (${{ matrix.os }})
+    needs: build-h2-binary
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-2025, windows-11-arm]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        env:
+          RUSTUP_MAX_RETRIES: "10"
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Retrieve this platform's same-run binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: h2-bin-${{ matrix.os }}--*
+          path: target/debug
+          merge-multiple: true
       - name: Assemble and archive prepared H2 package
         run: cargo run --locked --package xtask -- product-native-qualification-prepare
       - name: Retain same-run prepared H2 package

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -23,10 +23,12 @@ is the equivalent developer convenience interface.
 
 ## Focused checks
 
-Native product CI separates package preparation from lifecycle and scenario execution. Each platform
-builds its application and qualification tools once; the public installer lifecycle and all 18
-H2 scenarios consume that platform's same-run
-prepared artifact without rebuilding the application. The small xtask entry point still uses the
+Native product CI builds each of its seven native binaries in a separate bounded job on each
+platform, then assembles the downloaded binaries in a separate preparation job. Artifact names
+separate the platform and binary with a double hyphen so ARM and Intel macOS downloads cannot
+overlap. Assembly requires every binary and restores Unix executable permissions before use.
+The public installer lifecycle and all 18 H2 scenarios consume that platform's same-run prepared
+artifact without rebuilding the application. The small xtask entry point still uses the
 reviewed locked Cargo command; its prepared execution path never invokes Cargo. Missing artifacts
 fail rather than triggering a rebuild. The local build-and-qualify commands remain available, and
 every hosted job retains its ten-minute limit.

--- a/xtask/src/product_package.rs
+++ b/xtask/src/product_package.rs
@@ -1,6 +1,7 @@
 //! Product package build, installation, and native lifecycle qualification.
 
 mod host_version;
+mod native_artifacts;
 pub(crate) mod qualification;
 mod qualification_report;
 

--- a/xtask/src/product_package/native_artifacts.rs
+++ b/xtask/src/product_package/native_artifacts.rs
@@ -1,0 +1,108 @@
+//! Exact native binary inventory and permissions after same-run artifact download.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use super::{debug_binary, host_os};
+use crate::XtaskError;
+
+fn paths(root: &Path) -> Result<[PathBuf; 7], XtaskError> {
+    let helper = match host_os() {
+        "linux" => "peritus-linux-sandbox-helper",
+        "macos" => "peritus-macos-sandbox-helper",
+        "windows" => "peritus-windows-sandbox-helper",
+        _ => return Err(XtaskError::metadata("native product packaging is unsupported here")),
+    };
+    Ok([
+        "peritus",
+        "peritusd",
+        "peritus-tui",
+        helper,
+        "peritus-package",
+        "peritus-h2",
+        "peritus-h2-controller",
+    ]
+    .map(|name| debug_binary(root, name)))
+}
+
+/// Checks the full input inventory before restoring permissions lost by artifact download.
+pub(super) fn restore(root: &Path) -> Result<(), XtaskError> {
+    let paths = paths(root)?;
+    for path in &paths {
+        let metadata = fs::symlink_metadata(path).map_err(|error| {
+            XtaskError::io("inspect required native build artifact at", path, error)
+        })?;
+        if !metadata.file_type().is_file() {
+            return Err(XtaskError::metadata(format!(
+                "required native build artifact is not a regular file: {}",
+                path.display()
+            )));
+        }
+    }
+    #[cfg(unix)]
+    for path in &paths {
+        use std::os::unix::fs::PermissionsExt as _;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).map_err(|error| {
+            XtaskError::io("restore native build artifact permissions at", path, error)
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::product_package::SmokeSubject;
+
+    fn fixture(root: &Path) -> [PathBuf; 7] {
+        let paths = paths(root).expect("native paths");
+        fs::create_dir_all(root.join("target/debug")).expect("binary directory");
+        for path in &paths {
+            fs::write(path, b"artifact presence fixture").expect("binary fixture");
+        }
+        paths
+    }
+
+    #[test]
+    fn every_binary_is_required_and_directories_are_rejected() {
+        let subject = SmokeSubject::new().expect("subject");
+        let paths = fixture(subject.path());
+        restore(subject.path()).expect("complete inventory");
+        for path in &paths {
+            fs::remove_file(path).expect("remove exact fixture");
+            assert!(restore(subject.path()).is_err());
+            fs::create_dir(path).expect("directory impostor");
+            assert!(restore(subject.path()).is_err());
+            fs::remove_dir(path).expect("remove empty impostor");
+            fs::write(path, b"artifact presence fixture").expect("restore fixture");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn downloaded_permissions_are_restored_only_after_all_inputs_are_validated() {
+        use std::os::unix::fs::{PermissionsExt as _, symlink};
+
+        let subject = SmokeSubject::new().expect("subject");
+        let paths = fixture(subject.path());
+        for path in &paths {
+            fs::set_permissions(path, fs::Permissions::from_mode(0o644)).expect("download mode");
+        }
+        let last = paths.last().expect("last artifact");
+        fs::remove_file(last).expect("remove exact fixture");
+        symlink(&paths[0], last).expect("symlink impostor");
+        assert!(restore(subject.path()).is_err());
+        assert_eq!(
+            fs::metadata(&paths[0]).expect("first artifact").permissions().mode() & 0o777,
+            0o644
+        );
+        fs::remove_file(last).expect("remove fixture symlink");
+        fs::write(last, b"artifact presence fixture").expect("restore fixture");
+        restore(subject.path()).expect("restore executable permissions");
+        for path in &paths {
+            assert_eq!(fs::metadata(path).expect("artifact").permissions().mode() & 0o777, 0o755);
+        }
+    }
+}

--- a/xtask/src/product_package/qualification.rs
+++ b/xtask/src/product_package/qualification.rs
@@ -20,6 +20,7 @@ pub(crate) enum QualificationInput {
 
 /// Assembles and archives checked debug artifacts without rebuilding them or invoking Cargo.
 pub(crate) fn prepare(root: &Path) -> Result<PathBuf, XtaskError> {
+    super::native_artifacts::restore(root)?;
     let status = Command::new(debug_binary(root, "peritus-package"))
         .current_dir(root)
         .arg("--use-debug-artifacts")

--- a/xtask/src/release/publication/tests.rs
+++ b/xtask/src/release/publication/tests.rs
@@ -76,6 +76,7 @@ fn release_and_lifecycle_matrices_cover_each_native_target_once() {
         (&release, "assemble"),
         (&release, "attest"),
         (&product, "bootstrap"),
+        (&product, "prepare-h2"),
         (&product, "h2"),
     ] {
         let os = document["jobs"][job]["strategy"]["matrix"]["os"].as_vec().expect("OS matrix");
@@ -119,17 +120,7 @@ fn release_and_lifecycle_matrices_cover_each_native_target_once() {
 fn h2_preparation_is_once_per_native_target_with_every_scenario_retained() {
     let document = workflow(".github/workflows/product-package.yml");
     let prepare = &document["jobs"]["prepare-h2"];
-    let rows = prepare["strategy"]["matrix"]["include"].as_vec().expect("preparation matrix");
-    assert_eq!(rows.len(), TARGETS.len());
-    for (platform, _, runner) in TARGETS {
-        let matching =
-            rows.iter().filter(|row| row["os"].as_str() == Some(runner)).collect::<Vec<_>>();
-        assert_eq!(matching.len(), 1, "one preparation for {runner}");
-        assert_eq!(
-            matching[0]["helper"].as_str(),
-            Some(format!("peritus-sandbox-{platform}").as_str())
-        );
-    }
+    assert_eq!(prepare["needs"].as_str(), Some("build-h2-binary"));
     let h2 = &document["jobs"]["h2"];
     assert_eq!(h2["needs"].as_str(), Some("prepare-h2"));
     let shards = h2["strategy"]["matrix"]["shard"].as_vec().expect("scenarios");
@@ -137,7 +128,7 @@ fn h2_preparation_is_once_per_native_target_with_every_scenario_retained() {
     for (index, shard) in shards.iter().enumerate() {
         assert_eq!(shard.as_i64(), Some(i64::try_from(index).expect("index")));
     }
-    for job in ["bootstrap", "prepare-h2", "h2"] {
+    for job in ["bootstrap", "build-h2-binary", "prepare-h2", "h2"] {
         assert_eq!(document["jobs"][job]["timeout-minutes"].as_i64(), Some(10));
         assert_eq!(document["jobs"][job]["strategy"]["fail-fast"].as_bool(), Some(false));
     }
@@ -156,25 +147,84 @@ fn h2_and_lifecycle_only_execute_the_exact_same_run_prepared_artifact() {
     assert_eq!(upload["with"]["name"].as_str(), Some("h2-prepared-${{ matrix.os }}"));
     assert_eq!(upload["with"]["path"].as_str(), Some("target/h2-prepared.tar"));
     assert_eq!(upload["with"]["if-no-files-found"].as_str(), Some("error"));
-    let builds = preparation
-        .iter()
-        .filter_map(|step| step["run"].as_str())
-        .filter(|command| command.contains("cargo build"))
-        .collect::<Vec<_>>();
-    assert_eq!(builds.len(), 1);
-    for package in
-        ["xtask", "peritus-cli", "peritus-daemon", "peritus-tui", "peritus-platform-qualification"]
-    {
-        assert!(builds[0].contains(&format!("-p {package}")));
-    }
-    assert!(builds[0].contains("--locked --bins"));
-    assert!(builds[0].contains("-p ${{ matrix.helper }}"));
+    assert_eq!(
+        preparation.iter().filter_map(|step| step["run"].as_str()).collect::<Vec<_>>(),
+        ["cargo run --locked --package xtask -- product-native-qualification-prepare"]
+    );
     assert_prepared_consumer(
         &document,
         "h2",
         "product-native-qualification-prepared-shard ${{ matrix.shard }}",
     );
     assert_prepared_consumer(&document, "bootstrap", "release-bootstrap-prepared-smoke");
+}
+
+#[test]
+fn native_binary_builds_are_individually_bounded_and_downloads_cannot_cross_platforms() {
+    let document = workflow(".github/workflows/product-package.yml");
+    let build = &document["jobs"]["build-h2-binary"];
+    let rows = build["strategy"]["matrix"]["include"].as_vec().expect("binary matrix");
+    assert_eq!(rows.len(), TARGETS.len() * 7);
+    let mut artifact_names = std::collections::BTreeSet::new();
+    for (platform, _, runner) in TARGETS {
+        for (package, binary) in native_binary_inventory(platform) {
+            let matching = rows
+                .iter()
+                .filter(|row| {
+                    row["os"].as_str() == Some(runner)
+                        && row["package"].as_str() == Some(package.as_str())
+                        && row["binary"].as_str() == Some(binary.as_str())
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(matching.len(), 1, "exactly one build of {runner}/{binary}");
+            let suffix = if platform == "windows" { ".exe" } else { "" };
+            assert_eq!(
+                matching[0]["artifact"].as_str(),
+                Some(format!("{binary}{suffix}").as_str())
+            );
+            assert!(artifact_names.insert(format!("h2-bin-{runner}--{binary}")));
+        }
+    }
+    for (_, _, runner) in TARGETS {
+        let prefix = format!("h2-bin-{runner}--");
+        assert_eq!(artifact_names.iter().filter(|name| name.starts_with(&prefix)).count(), 7);
+    }
+    let steps = build["steps"].as_vec().expect("build steps");
+    assert_eq!(
+        steps.iter().filter_map(|step| step["run"].as_str()).collect::<Vec<_>>(),
+        ["cargo build --locked --package ${{ matrix.package }} --bin ${{ matrix.binary }}"]
+    );
+    let upload =
+        steps.iter().find(|step| step["with"]["name"].as_str().is_some()).expect("binary upload");
+    assert_eq!(
+        upload["with"]["name"].as_str(),
+        Some("h2-bin-${{ matrix.os }}--${{ matrix.binary }}")
+    );
+    assert_eq!(upload["with"]["path"].as_str(), Some("target/debug/${{ matrix.artifact }}"));
+    assert_eq!(upload["with"]["if-no-files-found"].as_str(), Some("error"));
+    assert_eq!(build["env"]["CARGO_BUILD_JOBS"].as_str(), Some("2"));
+    let prepare = document["jobs"]["prepare-h2"]["steps"].as_vec().expect("assembly steps");
+    let download = prepare
+        .iter()
+        .find(|step| step["with"]["pattern"].as_str().is_some())
+        .expect("binary download");
+    assert_eq!(download["with"].as_hash().expect("same-run download inputs").len(), 3);
+    assert_eq!(download["with"]["pattern"].as_str(), Some("h2-bin-${{ matrix.os }}--*"));
+    assert_eq!(download["with"]["path"].as_str(), Some("target/debug"));
+    assert_eq!(download["with"]["merge-multiple"].as_bool(), Some(true));
+}
+
+fn native_binary_inventory(platform: &str) -> Vec<(String, String)> {
+    let mut binaries = vec![
+        ("peritus-cli".to_owned(), "peritus".to_owned()),
+        ("peritus-daemon".to_owned(), "peritusd".to_owned()),
+        ("peritus-tui".to_owned(), "peritus-tui".to_owned()),
+        (format!("peritus-sandbox-{platform}"), format!("peritus-{platform}-sandbox-helper")),
+    ];
+    for binary in ["peritus-package", "peritus-h2", "peritus-h2-controller"] {
+        binaries.push(("peritus-platform-qualification".to_owned(), binary.to_owned()));
+    }
+    binaries
 }
 
 fn assert_prepared_consumer(document: &Yaml, job: &str, command: &str) {


### PR DESCRIPTION
## Cause
Main run 34043825810 cancelled Intel macOS H2 preparation at the retained ten-minute limit. Its combined binary build took 7m44s versus 4m40s in PR #48; assembly, upload, and runner finalization exhausted the remaining budget. The merged source tree was identical to the passing PR.

## Repair
- Build each of seven native binaries in a separate bounded job on all six native platforms, then assemble the same-run artifacts separately.
- Require every input to be a regular file and restore Unix executable permissions lost during artifact download.
- Delimit platform artifact names so macOS ARM downloads cannot include Intel binaries.
- Preserve the ten-minute ceiling, 108 H2 scenarios, six installer lifecycle checks, pinned actions, and failure propagation.

## Verification
- 302 xtask tests, strict Linux and Windows cross-target Clippy, formatting, actionlint, and repository policy checks passed.
- All seven exact Linux binary build commands passed.
- Real fresh-directory assembly from mode-0644 binaries passed, followed by installer lifecycle, public bootstrap, invalid-checksum rejection, and the H2 artifact-integrity scenario, with Cargo absent from PATH.
- Hosted validation passed at ad6cc794f3c5d814e4b36fa24fffada74d0e5cd2: all 544 checks and all four workflows succeeded. All 42 native binary builds, six assembly jobs, 108 H2 scenarios, and six installer lifecycle checks passed. Intel macOS assembly took 1m50s; its retried CLI build job finished in 7m59s. One transient GitHub artifact-upload DNS failure was retried successfully without code changes.

Failure evidence: https://github.com/Corvidae-Coding-Projects/Project-Peritus/actions/runs/34043825810/job/101515206577