### PR TITLE
fix(ci): isolate daemon tests within bounded native jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,9 @@ jobs:
           - { os: macos-15, operation: test-runner-product, shard: app-runner }
           - { os: windows-2025, operation: test-runner-recovery, shard: app-runner }
           - { os: windows-2025, operation: test-runner-product, shard: app-runner }
+          - { os: ubuntu-24.04, operation: test-daemon, shard: app-shell }
+          - { os: macos-15, operation: test-daemon, shard: app-shell }
+          - { os: windows-2025, operation: test-daemon, shard: app-shell }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/formal-governance.yml
+++ b/.github/workflows/formal-governance.yml
@@ -148,6 +148,9 @@ jobs:
           - { os: macos-15, operation: test-runner-product, shard: app-runner }
           - { os: windows-2025, operation: test-runner-recovery, shard: app-runner }
           - { os: windows-2025, operation: test-runner-product, shard: app-runner }
+          - { os: ubuntu-24.04, operation: test-daemon, shard: app-shell }
+          - { os: macos-15, operation: test-daemon, shard: app-shell }
+          - { os: windows-2025, operation: test-daemon, shard: app-shell }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -23,6 +23,14 @@ is the equivalent developer convenience interface.
 
 ## Focused checks
 
+Foundation and Gate A run `ci-shard test-daemon app-shell` separately from the
+ordinary `ci-shard test app-shell` job on Linux, macOS, and Windows. Together
+they select every application-shell package exactly once, with locked dependencies,
+all targets and features, serial tests, and the unchanged ten-minute job limit.
+Daemon build, Clippy, documentation, and Verus checks remain in the existing
+application-shell shards. Exact workflow checks reject missing, repeated, or
+misrouted daemon jobs.
+
 Native product CI builds each of its seven native binaries in a separate bounded job on each
 platform, then assembles the downloaded binaries in a separate preparation job. Artifact names
 separate the platform and binary with a double hyphen so ARM and Intel macOS downloads cannot

--- a/xtask/src/ci_shard.rs
+++ b/xtask/src/ci_shard.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::Command;
 
+const DAEMON_PACKAGE: &str = "peritus-daemon";
 const PLATFORM_PACKAGE: &str = "peritus-platform-qualification";
 const PLATFORM_TERMINAL_INTERACTIVE: &str =
     "terminal_interactive_round_trip_is_observed_and_reaped";
@@ -31,6 +32,7 @@ pub(crate) const SHARD_NAMES: [&str; 9] = [
 pub(crate) enum Operation {
     Build,
     Test,
+    TestDaemon,
     DocTest,
     Clippy,
     Docs,
@@ -50,6 +52,7 @@ impl Operation {
         match value {
             "build" => Some(Self::Build),
             "test" => Some(Self::Test),
+            "test-daemon" => Some(Self::TestDaemon),
             "doc-test" => Some(Self::DocTest),
             "clippy" => Some(Self::Clippy),
             "docs" => Some(Self::Docs),
@@ -143,6 +146,11 @@ fn selected_packages<'a>(
         .filter(|package| {
             verus_eligible(package, policy_by_name.get(package.name.as_str()), operation)
         })
+        .filter(|package| match operation {
+            Operation::Test => package.name != DAEMON_PACKAGE,
+            Operation::TestDaemon => package.name == DAEMON_PACKAGE,
+            _ => true,
+        })
         .filter(|package| !operation.is_platform_terminal() || package.name == PLATFORM_PACKAGE)
         .filter(|package| operation.runner_tests().is_none() || package.name == runner::PACKAGE)
         .map(|package| package.name.as_str())
@@ -188,7 +196,7 @@ fn cargo_command(root: &Path, operation: Operation, packages: &[&str]) -> Comman
                 "--all-features",
             ]);
         }
-        Operation::Test => {
+        Operation::Test | Operation::TestDaemon => {
             command.args(["test", "--locked", "--all-targets", "--all-features"]);
         }
         Operation::TestRunnerRecovery | Operation::TestRunnerProduct => {
@@ -237,7 +245,9 @@ fn cargo_command(root: &Path, operation: Operation, packages: &[&str]) -> Comman
         command.args(["--rlimit", "20"]);
     } else if let Some(test) = operation.platform_terminal_test() {
         command.args(["--test", "general_capability", test, "--", "--exact", "--test-threads=1"]);
-    } else if matches!(operation, Operation::Test) || operation.runner_tests().is_some() {
+    } else if matches!(operation, Operation::Test | Operation::TestDaemon)
+        || operation.runner_tests().is_some()
+    {
         command.args(["--", "--test-threads=1"]);
         if packages == [PLATFORM_PACKAGE] {
             for test in

--- a/xtask/src/ci_shard/tests.rs
+++ b/xtask/src/ci_shard/tests.rs
@@ -1,7 +1,10 @@
 use super::{
     Operation, PLATFORM_PACKAGE, PLATFORM_TERMINAL_CANCEL, PLATFORM_TERMINAL_INTERACTIVE,
-    PLATFORM_TERMINAL_SIGNAL, SHARD_NAMES, cargo_command, shard_for_layer, shard_for_package,
+    PLATFORM_TERMINAL_SIGNAL, SHARD_NAMES, cargo_command, selected_packages, shard_for_layer,
+    shard_for_package,
 };
+use crate::metadata;
+use std::collections::BTreeSet;
 use std::path::Path;
 
 #[test]
@@ -40,6 +43,65 @@ fn every_architecture_layer_has_one_stable_shard() {
 fn product_runner_has_an_independent_bounded_app_shard() {
     assert_eq!(shard_for_package("peritus-product-runner", "app"), Some("app-runner"));
     assert_eq!(shard_for_package("peritus-daemon", "app"), Some("app-shell"));
+}
+
+#[test]
+fn daemon_test_partition_preserves_every_workspace_package_exactly_once() {
+    let daemon = Operation::parse("test-daemon").expect("reviewed daemon test operation");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().expect("workspace root");
+    let policy = metadata::architecture_policy(root).expect("architecture policy");
+    let cargo = metadata::cargo_metadata(root).expect("workspace metadata");
+    let mut built = BTreeSet::new();
+    let mut tested = BTreeSet::new();
+    for shard in SHARD_NAMES {
+        built.extend(selected_packages(&policy, &cargo, Operation::Build, shard).expect("build"));
+        for package in selected_packages(&policy, &cargo, Operation::Test, shard).expect("test") {
+            assert!(tested.insert(package), "package tested in more than one regular shard");
+        }
+    }
+    assert!(!tested.contains("peritus-daemon"));
+    let dedicated = selected_packages(&policy, &cargo, daemon, "app-shell").expect("daemon");
+    assert_eq!(dedicated, ["peritus-daemon"]);
+    for package in dedicated {
+        assert!(tested.insert(package), "daemon tests must not run in the regular shell job");
+    }
+    assert_eq!(tested, built, "every built workspace package must retain its test assignment");
+    assert!(selected_packages(&policy, &cargo, daemon, "app-runner").is_err());
+
+    for operation in [
+        Operation::Build,
+        Operation::Clippy,
+        Operation::Docs,
+        Operation::DocTest,
+        Operation::VerusVerify,
+        Operation::VerusVerifyStrict,
+        Operation::VerusBuild,
+        Operation::VerusBuildStrict,
+    ] {
+        let packages = selected_packages(&policy, &cargo, operation, "app-shell").expect("shell");
+        assert!(packages.contains(&"peritus-daemon"), "only ordinary tests may be partitioned");
+    }
+}
+
+#[test]
+fn daemon_test_command_keeps_every_target_feature_and_serial_execution() {
+    let operation = Operation::parse("test-daemon").expect("reviewed daemon test operation");
+    let command = cargo_command(Path::new("."), operation, &["peritus-daemon"]);
+    let arguments =
+        command.get_args().map(|value| value.to_string_lossy().into_owned()).collect::<Vec<_>>();
+    assert_eq!(
+        arguments,
+        [
+            "test",
+            "--locked",
+            "--all-targets",
+            "--all-features",
+            "--package",
+            "peritus-daemon",
+            "--",
+            "--test-threads=1",
+        ]
+    );
 }
 
 #[test]

--- a/xtask/src/reproducibility/workflow_rust_matrix.rs
+++ b/xtask/src/reproducibility/workflow_rust_matrix.rs
@@ -23,13 +23,17 @@ const RUNNER_ENTRIES: [(&str, &str); 6] = [
     ("windows-2025", "test-runner-product"),
 ];
 
+const DAEMON_ENTRIES: [(&str, &str); 3] =
+    [("ubuntu-24.04", "test-daemon"), ("macos-15", "test-daemon"), ("windows-2025", "test-daemon")];
+
 pub(super) fn has_exact_test_includes(value: Option<&Yaml>) -> bool {
     let Some(entries) = value.and_then(Yaml::as_vec) else { return false };
     let expected = PLATFORM_TERMINAL_ENTRIES
         .into_iter()
         .map(|(os, operation)| (os, operation, "testing-platform"))
-        .chain(RUNNER_ENTRIES.into_iter().map(|(os, operation)| (os, operation, "app-runner")));
-    entries.len() == PLATFORM_TERMINAL_ENTRIES.len() + RUNNER_ENTRIES.len()
+        .chain(RUNNER_ENTRIES.into_iter().map(|(os, operation)| (os, operation, "app-runner")))
+        .chain(DAEMON_ENTRIES.into_iter().map(|(os, operation)| (os, operation, "app-shell")));
+    entries.len() == PLATFORM_TERMINAL_ENTRIES.len() + RUNNER_ENTRIES.len() + DAEMON_ENTRIES.len()
         && entries.iter().zip(expected).all(|(entry, expected)| {
             let Some(entry) = entry.as_hash() else { return false };
             entry.len() == 3
@@ -45,7 +49,7 @@ fn string<'a>(mapping: &'a yaml_rust2::yaml::Hash, key: &str) -> Option<&'a str>
 
 #[cfg(test)]
 mod tests {
-    use super::RUNNER_ENTRIES;
+    use super::{DAEMON_ENTRIES, RUNNER_ENTRIES};
     use crate::reproducibility::reproducibility_workflow_fixture::{
         canonical_ci, canonical_governance,
     };
@@ -53,7 +57,7 @@ mod tests {
     use crate::reproducibility::workflow_files::DocumentKind;
 
     #[test]
-    fn both_gates_require_each_native_runner_partition_exactly_once() {
+    fn both_gates_require_each_native_runner_and_daemon_partition_exactly_once() {
         for (path, canonical, message) in [
             (".github/workflows/ci.yml", canonical_ci(), "exact unconditional Rust shard matrix"),
             (
@@ -62,15 +66,24 @@ mod tests {
                 "does not retain every hardcoded job and final status",
             ),
         ] {
-            for (os, operation) in RUNNER_ENTRIES {
-                let entry = format!(
-                    "          - {{ os: {os}, operation: {operation}, shard: app-runner }}\n"
+            let entries = RUNNER_ENTRIES
+                .into_iter()
+                .map(|(os, operation)| (os, operation, "app-runner"))
+                .chain(
+                    DAEMON_ENTRIES.into_iter().map(|(os, operation)| (os, operation, "app-shell")),
                 );
+            for (os, operation, shard) in entries {
+                let entry =
+                    format!("          - {{ os: {os}, operation: {operation}, shard: {shard} }}\n");
+                let wrong_shard = if shard == "app-shell" { "app-runner" } else { "app-shell" };
                 for altered in [
                     canonical.replace(&entry, ""),
                     canonical.replace(&entry, &format!("{entry}{entry}")),
-                    canonical
-                        .replace(&entry, &entry.replace("shard: app-runner", "shard: app-shell")),
+                    canonical.replace(
+                        &entry,
+                        &entry
+                            .replace(&format!("shard: {shard}"), &format!("shard: {wrong_shard}")),
+                    ),
                 ] {
                     assert_ne!(altered, canonical, "fixture mutation must change the workflow");
                     let (_, diagnostics) = validate(path, DocumentKind::Workflow, &altered);


### PR DESCRIPTION
Separate daemon test execution from the remaining application-shell tests in Foundation and Gate A on Linux, macOS, and Windows.

The merged preparation hit the unchanged 10-minute Windows job ceiling after 57 seconds of xtask bootstrap, 6m26s of compilation, and 114.79 seconds of daemon unit tests. All assertions passed, but the job timed out as it finished. An earlier preparation job also exceeded the same bound.

The new test-daemon operation retains all targets, all features, locked dependencies, and serial execution. Build, Clippy, documentation, and Verus routing remain unchanged. No product code, dependency, release profile, timeout, or test assertion changes.

Verification: 318 xtask unit tests and 7 integration tests; 104 native daemon tests plus 145 native application-shell tests; strict Clippy, format check, actionlint, full repository policy, and changed-tool build passed. Exact-once workspace routing and exact command regressions failed before and pass after. Both workflow validators reject missing, duplicate, or misrouted daemon jobs. Native Windows/macOS timing remains to be verified by this PR CI.