### PR TITLE
fix(release): repair protected signing and Windows reproducibility

### DIFF
--- a/.github/workflows/distro-tools.yml
+++ b/.github/workflows/distro-tools.yml
@@ -22,3 +22,27 @@ jobs:
           toolchain: 1.97.1
       - name: Test distribution package tooling
         run: cargo run --locked --package xtask -- distro-test
+
+  windows-sqlite:
+    name: Windows bundled SQLite reproducibility
+    runs-on: windows-2025
+    timeout-minutes: 10
+    env:
+      CARGO_BUILD_JOBS: 2
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: 1.97.1
+      - name: Compare two fresh native compilations using the release C compiler
+        run: cargo run --locked --package xtask -- release-windows-sqlite-check
+      - name: Retain the observed native compiler and object digests
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-sqlite-rebuild
+          path: target/windows-sqlite-rebuild.json
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,8 +275,13 @@ jobs:
         run: >-
           cargo build --release --locked --package ${{ matrix.target.package }}
           --bin ${{ matrix.target.binary }}
-      - name: Link the native Windows release binary deterministically
-        if: ${{ runner.os == 'Windows' }}
+      - name: Compile native Windows x86-64 with the pinned reproducible C compiler
+        if: ${{ matrix.target.os == 'windows-2025' }}
+        env:
+          PERITUS_RELEASE_BINARY: ${{ matrix.target.binary }}
+        run: cargo run --locked --package xtask -- release-windows-binary
+      - name: Link the native Windows ARM64 release binary deterministically
+        if: ${{ matrix.target.os == 'windows-11-arm' }}
         run: >-
           cargo rustc --release --locked --package ${{ matrix.target.package }}
           --bin ${{ matrix.target.binary }} -- -C link-arg=/Brepro

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -235,6 +235,14 @@ The package contains `manifest.toml`, `SHA256SUMS`, four executables, lifecycle 
 Native CI runs the lifecycle and all 18 H2 scenarios on each release target.
 
 Tagged release jobs build each binary on its target system.
+Windows x86-64 uses native `clang-cl` 20.1.8 for C dependencies and the MSVC ABI,
+with the locked Rust toolchain and `/Brepro` final linking. This avoids an
+observed MSVC C-code generation difference between otherwise identical SQLite
+builds. The compiler version, target and executable hash are recorded in build
+logs; unexpected compiler versions fail rather than falling back. CI also
+compares two fresh bundled SQLite compilations. Windows ARM64 retains its
+native toolchain. All six targets still require byte-identical independent
+release archives; no executable bytes are rewritten to make comparisons pass.
 They attach archives, checksums, inventories, SBOMs, provenance, and GitHub attestations to a draft release.
 Publication requires all six target archives and their evidence, plus signed
 Debian/RPM bundles and main packages for both Linux architectures.

--- a/packaging/distro/README.md
+++ b/packaging/distro/README.md
@@ -180,7 +180,14 @@ Before a first release:
 
 CI imports the supplied secret only into an ephemeral GnuPG home, checks the
 reviewed fingerprint and exact tag/commit, signs, qualifies, then uploads to the
-existing draft. Signing secrets are scoped to the signing step. The public key
+existing draft. After validating the passphrase with a loopback signature, it
+seeds the agent's [separate restricted cache](https://lists.gnupg.org/pipermail/gnupg-users/2023-March/066472.html)
+using `gpg-preset-passphrase --restricted` over standard input. Only the
+restricted socket and public key enter package containers; private-key material
+and passphrases do not. Interactive pinentry is disabled for this ephemeral CI
+agent, and the agent and keyring are removed on success or failure. A regression
+test uses a disposable protected key and an actual public-only restricted client.
+Signing secrets are scoped to the signing step. The public key
 asset has one matrix owner to prevent concurrent upload races. Draft completion
 requires all six native archives/evidence sets, all four signed distribution
 bundles, all four main native packages, the public key, and both bootstraps with

--- a/packaging/distro/ci_sign.py
+++ b/packaging/distro/ci_sign.py
@@ -2,11 +2,25 @@
 
 import os
 from pathlib import Path
+import re
 import subprocess
 import tempfile
 
 from common import run, version
 from sign import fingerprint, sign
+
+
+def seed_restricted_cache(key, passphrase):
+    """The extra socket has a separate cache; a normal loopback signature does not seed it."""
+    metadata = run("gpg", "--batch", "--with-colons", "--with-keygrip",
+                   "--list-secret-keys", key, capture=True)
+    grips = {line.split(":")[9] for line in metadata.splitlines() if line.startswith("grp:")}
+    if not grips or any(not re.fullmatch(r"[A-F0-9]{40}", grip) for grip in grips):
+        raise ValueError("CI signing key has no valid agent keygrips")
+    preset = Path(run("gpgconf", "--list-dirs", "libexecdir", capture=True)) / "gpg-preset-passphrase"
+    for grip in sorted(grips):
+        # Send only over stdin to the host agent. Neither argv nor the container gets the password.
+        run(preset, "--preset", "--restricted", grip, input=passphrase + "\n")
 
 
 def sign_ci():
@@ -23,6 +37,9 @@ def sign_ci():
     previous = os.environ.get("GNUPGHOME")
     with tempfile.TemporaryDirectory(prefix="peritus-ci-signing-") as temporary:
         home = Path(temporary)
+        # This configuration belongs only to this disposable CI agent, never the user's agent.
+        # Pinentry is unavailable on hosted runners; an unexpected prompt must fail immediately.
+        (home / "gpg-agent.conf").write_text("allow-preset-passphrase\npinentry-program /bin/false\n")
         os.environ["GNUPGHOME"] = str(home)
         try:
             imported = subprocess.run(["gpg", "--batch", "--import"], text=True, input=secret,
@@ -37,11 +54,14 @@ def sign_ci():
             run("gpg", "--batch", "--local-user", key, "--pinentry-mode", "loopback",
                 "--passphrase-fd", "0", "--output", home / "agent-check.sig",
                 "--detach-sign", primer, input=passphrase + "\n")
+            seed_restricted_cache(key, passphrase)
             passphrase = ""
             sign()
         finally:
-            run("gpgconf", "--kill", "gpg-agent")
-            if previous is None:
-                os.environ.pop("GNUPGHOME", None)
-            else:
-                os.environ["GNUPGHOME"] = previous
+            try:
+                run("gpgconf", "--kill", "gpg-agent")
+            finally:
+                if previous is None:
+                    os.environ.pop("GNUPGHOME", None)
+                else:
+                    os.environ["GNUPGHOME"] = previous

--- a/packaging/distro/test_ci_sign.py
+++ b/packaging/distro/test_ci_sign.py
@@ -1,0 +1,121 @@
+"""Exercise CI signing with a disposable protected key and the real restricted agent."""
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import ci_sign
+
+
+class RestrictedCacheTests(unittest.TestCase):
+    def test_only_selected_keygrips_are_seeded_over_stdin(self):
+        grip = "A" * 40
+        metadata = f"grp:::::::::{grip}:\ngrp:::::::::{grip}:\n"
+        with patch.object(ci_sign, "run", side_effect=[metadata, "/usr/libexec", None]) as run:
+            ci_sign.seed_restricted_cache("B" * 40, "test-only password")
+        self.assertEqual(run.call_args_list[0].args[-1], "B" * 40)
+        self.assertEqual(run.call_args_list[-1].args,
+                         (Path("/usr/libexec/gpg-preset-passphrase"), "--preset", "--restricted", grip))
+        self.assertEqual(run.call_args_list[-1].kwargs, {"input": "test-only password\n"})
+
+    def test_missing_or_invalid_keygrips_cannot_seed_the_agent(self):
+        for metadata in ("", "grp:::::::::invalid:", "grp:::::::::" + "A" * 39 + ":"):
+            with self.subTest(metadata=metadata), \
+                    patch.object(ci_sign, "run", return_value=metadata) as run:
+                with self.assertRaisesRegex(ValueError, "valid agent keygrips"):
+                    ci_sign.seed_restricted_cache("B" * 40, "test-only password")
+                self.assertEqual(run.call_count, 1)
+
+
+@unittest.skipUnless(shutil.which("gpg") and shutil.which("gpgconf") and os.name == "posix",
+                     "requires native GnuPG and Unix agent sockets")
+class CiSigningAgentTests(unittest.TestCase):
+    def command(self, *arguments, env, input=None, check=True):
+        return subprocess.run(arguments, env=env, input=input, text=True, check=check,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+
+    def test_protected_key_signs_through_public_only_restricted_client(self):
+        # This key is generated for this test only. Never inspect or export the user's keyring.
+        with tempfile.TemporaryDirectory(prefix="peritus-test-key-") as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            source.mkdir(mode=0o700)
+            source_env = {**os.environ, "GNUPGHOME": str(source)}
+            password = "disposable CI regression key"
+            try:
+                self.command("gpg", "--batch", "--pinentry-mode", "loopback",
+                             "--passphrase-fd", "0", "--quick-generate-key",
+                             "Peritus Test <test@example.invalid>", "ed25519", "sign", "0",
+                             env=source_env, input=password + "\n")
+                listing = self.command("gpg", "--with-colons", "--list-secret-keys",
+                                       env=source_env).stdout
+                key = next(line.split(":")[9] for line in listing.splitlines()
+                           if line.startswith("fpr:"))
+                public = self.command("gpg", "--armor", "--export", key, env=source_env).stdout
+                private = self.command("gpg", "--batch", "--pinentry-mode", "loopback",
+                                       "--passphrase-fd", "0", "--armor", "--export-secret-keys",
+                                       key, env=source_env, input=password + "\n").stdout
+            finally:
+                self.command("gpgconf", "--kill", "gpg-agent", env=source_env)
+
+            observed = []
+            temporary_directory = tempfile.TemporaryDirectory
+
+            @contextmanager
+            def headless_ci_home(**options):
+                with temporary_directory(**options) as directory:
+                    (Path(directory) / "gpg-agent.conf").write_text("pinentry-program /bin/false\n")
+                    yield directory
+
+            def restricted_sign():
+                host_env = dict(os.environ)
+                observed.append(Path(host_env["GNUPGHOME"]))
+                self.assertNotIn("PERITUS_SIGNING_KEY", host_env)
+                self.assertNotIn("PERITUS_SIGNING_PASSPHRASE", host_env)
+                client = root / "client"
+                client.mkdir(mode=0o700)
+                (client / "gpg.conf").write_text("no-autostart\n")
+                socket = self.command("gpgconf", "--list-dirs", "agent-extra-socket",
+                                      env=host_env).stdout.strip()
+                client_env = {**host_env, "GNUPGHOME": str(client)}
+                self.command("gpgconf", "--create-socketdir", env=client_env)
+                client_socket = Path(self.command("gpgconf", "--list-dirs", "agent-socket",
+                                                  env=client_env).stdout.strip())
+                client_socket.symlink_to(socket)
+                try:
+                    self.command("gpg", "--batch", "--import", env=client_env, input=public)
+                    payload = root / "payload"
+                    payload.write_text("Disposable release-signing regression payload.\n")
+                    signature = root / "payload.sig"
+                    # Never prompt during a regression, even if the agent cache is empty.
+                    result = self.command("gpg", "--batch",
+                                          "--local-user", key, "--output", str(signature),
+                                          "--detach-sign", str(payload), env=client_env, check=False)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.command("gpg", "--batch", "--verify", str(signature), str(payload),
+                                 env=client_env)
+                    self.assertFalse((client / "private-keys-v1.d").exists())
+                finally:
+                    client_socket.unlink()
+                    self.command("gpgconf", "--remove-socketdir", env=client_env)
+
+            with patch.dict(os.environ, GITHUB_ACTIONS="true", GITHUB_REF_NAME="v1.2.3",
+                            PERITUS_SIGNING_KEY=private, PERITUS_SIGNING_PASSPHRASE=password), \
+                    patch.object(ci_sign, "version", return_value="1.2.3"), \
+                    patch.object(ci_sign, "fingerprint", return_value=key), \
+                    patch.object(ci_sign.tempfile, "TemporaryDirectory", headless_ci_home), \
+                    patch.object(ci_sign, "sign", side_effect=restricted_sign):
+                previous = os.environ.get("GNUPGHOME")
+                ci_sign.sign_ci()
+                self.assertEqual(os.environ.get("GNUPGHOME"), previous)
+            self.assertEqual(len(observed), 1)
+            self.assertFalse(observed[0].exists(), "ephemeral CI keyring must be removed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packaging/test_windows_release.py
+++ b/packaging/test_windows_release.py
@@ -1,0 +1,98 @@
+"""Fail-closed compiler selection and clean-build comparison tests."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import windows_release as release
+
+
+class WindowsReleaseTests(unittest.TestCase):
+    def test_compiler_requires_native_host_exact_version_and_msvc_abi(self):
+        valid = "clang version 20.1.8\nTarget: x86_64-pc-windows-msvc\nThread model: posix"
+        for system, machine, compiler, version, error in (
+            ("Linux", "x86_64", "clang-cl", valid, "native x86-64 Windows"),
+            ("Windows", "ARM64", "clang-cl", valid, "native x86-64 Windows"),
+            ("Windows", "AMD64", None, valid, "install the pinned"),
+            ("Windows", "AMD64", "clang-cl", valid.replace("20.1.8", "21.1.0"), "must be clang-cl"),
+            ("Windows", "AMD64", "clang-cl", valid.replace("msvc", "gnu"), "MSVC ABI"),
+        ):
+            with self.subTest(system=system, machine=machine, compiler=compiler, version=version), \
+                    patch.object(release.platform, "system", return_value=system), \
+                    patch.object(release.platform, "machine", return_value=machine), \
+                    patch.object(release.shutil, "which", return_value=compiler), \
+                    patch.object(release.subprocess, "check_output", return_value=version):
+                with self.assertRaisesRegex(ValueError, error):
+                    release.compiler_environment()
+        with patch.object(release.platform, "system", return_value="Windows"), \
+                patch.object(release.platform, "machine", return_value="AMD64"), \
+                patch.object(release.shutil, "which", return_value="native/clang-cl.exe"), \
+                patch.object(release.subprocess, "check_output", return_value=valid), \
+                patch.object(release, "digest", return_value="a" * 64):
+            environment, record = release.compiler_environment()
+        self.assertEqual(environment["CC_x86_64_pc_windows_msvc"], "native/clang-cl.exe")
+        self.assertEqual(record["version"], valid)
+        self.assertEqual(record["sha256"], "a" * 64)
+
+    def test_binary_build_preserves_locked_release_and_deterministic_linker(self):
+        for binary, package in release.BINARIES.items():
+            with self.subTest(binary=binary), \
+                    patch.object(release, "compiler_environment", return_value=({"CC": "fixture"}, {})), \
+                    patch.object(release.subprocess, "run") as run:
+                release.build(binary)
+            self.assertEqual(run.call_args.args[0], [
+                "cargo", "rustc", "--release", "--locked", "--package", package,
+                "--bin", binary, "--", "-C", "link-arg=/Brepro"])
+            self.assertEqual(run.call_args.kwargs, {"cwd": release.ROOT,
+                                                    "env": {"CC": "fixture"}, "check": True})
+
+    def test_comparison_requires_two_distinct_clean_builds_and_exact_object_bytes(self):
+        for identical in (True, False):
+            with self.subTest(identical=identical), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                destinations = []
+
+                def compile_fixture(arguments, **options):
+                    self.assertEqual(arguments[:7], ["cargo", "build", "--release", "--locked",
+                                                     "--package", "peritus-journal", "--target-dir"])
+                    target = Path(arguments[-1])
+                    self.assertFalse(target.exists())
+                    destinations.append(target)
+                    output = target / "release/build/libsqlite3-sys-fixture/out"
+                    output.mkdir(parents=True)
+                    content = b"test-only native object"
+                    if not identical and len(destinations) == 2:
+                        content += b"different"
+                    (output / "fixture-sqlite3.o").write_bytes(content)
+
+                with patch.object(release, "ROOT", root), \
+                        patch.object(release, "compiler_environment", return_value=({}, {"test": True})), \
+                        patch.object(release.subprocess, "run", side_effect=compile_fixture):
+                    if identical:
+                        release.check_sqlite()
+                    else:
+                        with self.assertRaisesRegex(ValueError, "compilations differ"):
+                            release.check_sqlite()
+                self.assertEqual(len(set(destinations)), 2)
+                report = json.loads((root / "target/windows-sqlite-rebuild.json").read_text())
+                self.assertIs(report["byte_identical"], identical)
+                self.assertEqual(len(report["objects"]), 2)
+
+    def test_object_selection_rejects_missing_or_ambiguous_outputs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with self.assertRaisesRegex(ValueError, "exactly one"):
+                release.sqlite_object(root)
+            output = root / "release/build/libsqlite3-sys-fixture/out"
+            output.mkdir(parents=True)
+            (output / "first-sqlite3.o").write_bytes(b"test-only object")
+            self.assertEqual(release.sqlite_object(root), output / "first-sqlite3.o")
+            (output / "second-sqlite3.o").write_bytes(b"test-only object")
+            with self.assertRaisesRegex(ValueError, "exactly one"):
+                release.sqlite_object(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packaging/windows_release.py
+++ b/packaging/windows_release.py
@@ -1,0 +1,93 @@
+"""Native x86-64 Windows release builds with an explicit, reproducible C compiler."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parent.parent
+CLANG_VERSION = "20.1.8"
+BINARIES = {
+    "peritus": "peritus-cli",
+    "peritusd": "peritus-daemon",
+    "peritus-tui": "peritus-tui",
+    "peritus-windows-sandbox-helper": "peritus-sandbox-windows",
+}
+
+
+def digest(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def compiler_environment():
+    if platform.system() != "Windows" or platform.machine().lower() not in ("amd64", "x86_64"):
+        raise ValueError("the pinned C compiler requires a native x86-64 Windows host")
+    compiler = shutil.which("clang-cl")
+    if compiler is None:
+        raise ValueError("install the pinned native LLVM clang-cl compiler before release compilation")
+    observed = subprocess.check_output([compiler, "--version"], text=True).strip()
+    if not re.search(r"^clang version " + re.escape(CLANG_VERSION) + r"(?:\s|$)", observed):
+        raise ValueError(f"release C compiler must be clang-cl {CLANG_VERSION}; observed {observed}")
+    if "Target: x86_64-pc-windows-msvc" not in observed:
+        raise ValueError("release C compiler must target the native Windows MSVC ABI")
+    record = {"path": compiler, "version": observed, "sha256": digest(Path(compiler))}
+    print(json.dumps({"native_c_compiler": record}, sort_keys=True), flush=True)
+    return {**os.environ, "CC_x86_64_pc_windows_msvc": compiler}, record
+
+
+def build(binary):
+    package = BINARIES[binary]
+    environment, _ = compiler_environment()
+    subprocess.run(["cargo", "rustc", "--release", "--locked", "--package", package,
+                    "--bin", binary, "--", "-C", "link-arg=/Brepro"],
+                   cwd=ROOT, env=environment, check=True)
+
+
+def sqlite_object(target):
+    files = list(target.glob("release/build/libsqlite3-sys-*/out/*sqlite3.o"))
+    files += list(target.glob("release/build/libsqlite3-sys-*/out/*sqlite3.obj"))
+    if len(files) != 1 or not files[0].is_file() or files[0].is_symlink():
+        raise ValueError("expected exactly one freshly compiled bundled SQLite object")
+    return files[0]
+
+
+def check_sqlite():
+    environment, compiler = compiler_environment()
+    (ROOT / "target").mkdir(exist_ok=True)
+    # Retain both fresh build trees, including on failure, for compiler-level diagnosis.
+    directory = Path(tempfile.mkdtemp(prefix="windows-sqlite-repro-", dir=ROOT / "target"))
+    observations = []
+    for role in ("first", "second"):
+        target = directory / role
+        subprocess.run(["cargo", "build", "--release", "--locked", "--package", "peritus-journal",
+                        "--target-dir", str(target)], cwd=ROOT, env=environment, check=True)
+        payload = sqlite_object(target)
+        observations.append({"role": role, "object": str(payload), "sha256": digest(payload)})
+    identical = observations[0]["sha256"] == observations[1]["sha256"]
+    report = {"compiler": compiler, "objects": observations, "byte_identical": identical}
+    (ROOT / "target/windows-sqlite-rebuild.json").write_text(json.dumps(report, indent=2) + "\n")
+    if not identical:
+        raise ValueError("fresh native SQLite compilations differ; inspect windows-sqlite-rebuild.json")
+    print("Two fresh native bundled SQLite compilations are byte-identical", flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("build", "check-sqlite"))
+    parser.add_argument("binary", nargs="?", choices=tuple(BINARIES))
+    arguments = parser.parse_args()
+    if arguments.operation == "build":
+        if arguments.binary is None:
+            parser.error("build requires a binary")
+        build(arguments.binary)
+    else:
+        if arguments.binary is not None:
+            parser.error("check-sqlite does not accept a binary")
+        check_sqlite()

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -45,6 +45,8 @@ Commands:
   release-daemon-library Compile and retain a same-run native daemon library tree
   release-daemon-binary Compile the final daemon from its verified same-role library tree
   release-cli-binary     Compile the CLI from its verified same-role daemon libraries
+  release-windows-binary Compile a selected native Windows x86-64 binary with pinned C tooling
+  release-windows-sqlite-check Compare two fresh native Windows bundled SQLite compilations
   release-create         Validate a tag and create its retained draft GitHub release
   release-package-stage Build, archive, checksum, and record this host's native package
   release-package-assemble Assemble a native package from separately built release binaries

--- a/xtask/src/cli/tests.rs
+++ b/xtask/src/cli/tests.rs
@@ -33,6 +33,8 @@ fn native_rebuild_commands_select_exact_operations() {
         ("release-daemon-library", Operation::Library),
         ("release-daemon-binary", Operation::DaemonBinary),
         ("release-cli-binary", Operation::CliBinary),
+        ("release-windows-binary", Operation::WindowsBinary),
+        ("release-windows-sqlite-check", Operation::WindowsSqliteCheck),
     ] {
         assert_eq!(
             parse([OsString::from(name)]).expect("rebuild command"),

--- a/xtask/src/release/publication/tests/distribution.rs
+++ b/xtask/src/release/publication/tests/distribution.rs
@@ -88,6 +88,7 @@ fn release_build_capacity_is_scoped_without_loosening_profiles_or_deadlines() {
         commands,
         [
             "cargo build --release --locked --package ${{ matrix.target.package }} --bin ${{ matrix.target.binary }}",
+            "cargo run --locked --package xtask -- release-windows-binary",
             "cargo rustc --release --locked --package ${{ matrix.target.package }} --bin ${{ matrix.target.binary }} -- -C link-arg=/Brepro",
             "cargo run --locked --package xtask -- release-daemon-binary",
             "cargo run --locked --package xtask -- release-cli-binary"

--- a/xtask/src/release/publication/tests/native_compilation.rs
+++ b/xtask/src/release/publication/tests/native_compilation.rs
@@ -63,17 +63,18 @@ fn every_binary_keeps_its_native_command_or_uses_only_its_verified_daemon_librar
     let document = workflow(".github/workflows/release.yml");
     let steps = document["jobs"]["build-binary"]["steps"].as_vec().expect("binary steps");
     let commands = steps.iter().filter(|step| step["run"].as_str().is_some()).collect::<Vec<_>>();
-    assert_eq!(commands.len(), 4);
+    assert_eq!(commands.len(), 5);
     assert_eq!(
         commands[0]["if"].as_str(),
         Some(
             "${{ runner.os != 'Windows' && (matrix.target.os != 'macos-15-intel' || (matrix.target.binary != 'peritusd' && matrix.target.binary != 'peritus')) }}"
         )
     );
-    assert_eq!(commands[1]["if"].as_str(), Some("${{ runner.os == 'Windows' }}"));
-    assert_eq!(commands[2]["if"].as_str(), Some(DAEMON));
+    assert_eq!(commands[1]["if"].as_str(), Some("${{ matrix.target.os == 'windows-2025' }}"));
+    assert_eq!(commands[2]["if"].as_str(), Some("${{ matrix.target.os == 'windows-11-arm' }}"));
+    assert_eq!(commands[3]["if"].as_str(), Some(DAEMON));
     assert_eq!(
-        commands[2]["env"]["PERITUS_RELEASE_BUILD_ROLE"].as_str(),
+        commands[3]["env"]["PERITUS_RELEASE_BUILD_ROLE"].as_str(),
         Some("${{ matrix.build }}")
     );
     let evidence = steps

--- a/xtask/src/release/publication/tests/native_windows.rs
+++ b/xtask/src/release/publication/tests/native_windows.rs
@@ -1,24 +1,36 @@
-//! Windows release determinism belongs to final native linking, not byte rewriting.
+//! Windows release determinism belongs to native compilation and linking, not byte rewriting.
 
 use super::*;
 
 #[test]
-fn windows_release_binaries_request_determinism_only_from_the_final_native_linker() {
+fn windows_release_binaries_use_reviewed_native_compilation_and_deterministic_linking() {
     let document = workflow(".github/workflows/release.yml");
     let build = &document["jobs"]["build-binary"];
     let steps = build["steps"].as_vec().expect("binary steps");
-    let native = steps
-        .iter()
-        .filter(|step| step["if"].as_str() == Some("${{ runner.os == 'Windows' }}"))
-        .collect::<Vec<_>>();
-    assert_eq!(native.len(), 1, "one deterministic native Windows compilation step");
-    assert!(native[0]["env"].is_badvalue(), "no ambient compiler or linker overrides");
-    assert_eq!(
-        native[0]["run"].as_str(),
-        Some(
-            "cargo rustc --release --locked --package ${{ matrix.target.package }} --bin ${{ matrix.target.binary }} -- -C link-arg=/Brepro"
-        )
-    );
+    for (condition, command) in [
+        (
+            "${{ matrix.target.os == 'windows-2025' }}",
+            "cargo run --locked --package xtask -- release-windows-binary",
+        ),
+        (
+            "${{ matrix.target.os == 'windows-11-arm' }}",
+            "cargo rustc --release --locked --package ${{ matrix.target.package }} --bin ${{ matrix.target.binary }} -- -C link-arg=/Brepro",
+        ),
+    ] {
+        let native =
+            steps.iter().filter(|step| step["if"].as_str() == Some(condition)).collect::<Vec<_>>();
+        assert_eq!(native.len(), 1, "one reviewed compilation step per native Windows target");
+        if command.ends_with("release-windows-binary") {
+            assert_eq!(native[0]["env"].as_hash().expect("binary selection").len(), 1);
+            assert_eq!(
+                native[0]["env"]["PERITUS_RELEASE_BINARY"].as_str(),
+                Some("${{ matrix.target.binary }}")
+            );
+        } else {
+            assert!(native[0]["env"].is_badvalue(), "no ambient compiler or linker overrides");
+        }
+        assert_eq!(native[0]["run"].as_str(), Some(command));
+    }
     assert_eq!(build["runs-on"].as_str(), Some("${{ matrix.target.os }}"));
     for runner in ["windows-2025", "windows-11-arm"] {
         let rows = build["strategy"]["matrix"]["target"]

--- a/xtask/src/release/rebuild.rs
+++ b/xtask/src/release/rebuild.rs
@@ -11,6 +11,8 @@ pub(crate) enum Operation {
     Library,
     DaemonBinary,
     CliBinary,
+    WindowsBinary,
+    WindowsSqliteCheck,
 }
 
 impl Operation {
@@ -21,31 +23,50 @@ impl Operation {
             "release-daemon-library" => Some(Self::Library),
             "release-daemon-binary" => Some(Self::DaemonBinary),
             "release-cli-binary" => Some(Self::CliBinary),
+            "release-windows-binary" => Some(Self::WindowsBinary),
+            "release-windows-sqlite-check" => Some(Self::WindowsSqliteCheck),
             _ => None,
         }
     }
 }
 
 pub(crate) fn run(root: &Path, operation: Operation) -> Result<(), XtaskError> {
-    let role = if operation == Operation::Compare {
+    let role = if matches!(
+        operation,
+        Operation::Compare | Operation::WindowsBinary | Operation::WindowsSqliteCheck
+    ) {
         None
     } else {
         Some(env::var("PERITUS_RELEASE_BUILD_ROLE").map_err(|_| {
             XtaskError::invocation("PERITUS_RELEASE_BUILD_ROLE must be primary or independent")
         })?)
     };
+    let binary = if operation == Operation::WindowsBinary {
+        Some(env::var("PERITUS_RELEASE_BINARY").map_err(|_| {
+            XtaskError::invocation("PERITUS_RELEASE_BINARY must select a reviewed Windows binary")
+        })?)
+    } else {
+        None
+    };
     super::run(
-        &mut command(root, operation, role.as_deref())?,
+        &mut command(root, operation, role.as_deref(), binary.as_deref())?,
         "run native release build operation",
     )
 }
 
-fn command(root: &Path, operation: Operation, role: Option<&str>) -> Result<Command, XtaskError> {
+fn command(
+    root: &Path,
+    operation: Operation,
+    role: Option<&str>,
+    binary: Option<&str>,
+) -> Result<Command, XtaskError> {
     let mut command = Command::new(if cfg!(windows) { "python" } else { "python3" });
     let script =
         if matches!(operation, Operation::Library | Operation::DaemonBinary | Operation::CliBinary)
         {
             "packaging/native_build.py"
+        } else if matches!(operation, Operation::WindowsBinary | Operation::WindowsSqliteCheck) {
+            "packaging/windows_release.py"
         } else {
             "packaging/rebuild.py"
         };
@@ -71,6 +92,22 @@ fn command(root: &Path, operation: Operation, role: Option<&str>) -> Result<Comm
             command.env("PERITUS_RELEASE_BUILD_ROLE", require_role(role)?);
             command.args(["binary", binary]);
         }
+        Operation::WindowsBinary => {
+            let binary = binary
+                .filter(|value| {
+                    matches!(
+                        *value,
+                        "peritus" | "peritusd" | "peritus-tui" | "peritus-windows-sandbox-helper"
+                    )
+                })
+                .ok_or_else(|| {
+                    XtaskError::invocation("release requires a reviewed Windows binary")
+                })?;
+            command.args(["build", binary]);
+        }
+        Operation::WindowsSqliteCheck => {
+            command.arg("check-sqlite");
+        }
     }
     Ok(command)
 }
@@ -94,14 +131,14 @@ mod tests {
                 Operation::DaemonBinary,
                 Operation::CliBinary,
             ] {
-                assert!(command(root, operation, role).is_err());
+                assert!(command(root, operation, role, None).is_err());
             }
         }
         for role in ["primary", "independent"] {
-            let command = command(root, Operation::Record, Some(role)).expect("record");
+            let command = command(root, Operation::Record, Some(role), None).expect("record");
             assert_eq!(command.get_args().skip(1).collect::<Vec<_>>(), ["record", "dist", role]);
         }
-        let command = command(root, Operation::Compare, None).expect("comparison");
+        let command = command(root, Operation::Compare, None, None).expect("comparison");
         assert_eq!(
             command.get_args().skip(1).collect::<Vec<_>>(),
             [
@@ -121,7 +158,7 @@ mod tests {
             (Operation::CliBinary, vec!["binary", "peritus"]),
         ] {
             for role in ["primary", "independent"] {
-                let command = command(Path::new("."), operation, Some(role)).expect("phase");
+                let command = command(Path::new("."), operation, Some(role), None).expect("phase");
                 let script = Path::new(".").join("packaging/native_build.py");
                 assert_eq!(command.get_args().next(), Some(script.as_os_str()));
                 assert_eq!(command.get_args().skip(1).collect::<Vec<_>>(), arguments);
@@ -130,5 +167,25 @@ mod tests {
                 }));
             }
         }
+    }
+
+    #[test]
+    fn windows_operations_reject_arbitrary_binaries_and_use_the_reviewed_script() {
+        let root = Path::new(".");
+        for binary in [None, Some(""), Some("other"), Some("peritus; exit 0")] {
+            assert!(command(root, Operation::WindowsBinary, None, binary).is_err());
+        }
+        for binary in ["peritus", "peritusd", "peritus-tui", "peritus-windows-sandbox-helper"] {
+            let command =
+                command(root, Operation::WindowsBinary, None, Some(binary)).expect("binary");
+            assert_eq!(command.get_args().skip(1).collect::<Vec<_>>(), ["build", binary]);
+            assert_eq!(
+                command.get_args().next(),
+                Some(root.join("packaging/windows_release.py").as_os_str())
+            );
+        }
+        let command =
+            command(root, Operation::WindowsSqliteCheck, None, None).expect("SQLite check");
+        assert_eq!(command.get_args().skip(1).collect::<Vec<_>>(), ["check-sqlite"]);
     }
 }


### PR DESCRIPTION
## Summary
- Seed GnuPG restricted cache via stdin after validating the passphrase; preserve the public-only restricted package-container boundary.
- Add a real disposable protected-key signing regression, which reproduced the original failure and now passes locally and on the Ubuntu runner.
- Address the separate Windows x86_64 daemon mismatch: the prior independent builds differed in bundled SQLite native instruction bytes, not just timestamps.
- Select native clang-cl 20.1.8 for Windows x86_64 C dependencies, validate its MSVC ABI target, and record compiler version/hash. Keep Rust release profile, final /Brepro linking, native ARM64, and strict full-archive comparison unchanged.
- Add two fresh native SQLite compilation checks and typed reviewed release entry points. No artifact rewriting or signature/protection bypass.

## Verification
- 44 distribution-tooling tests; 43 native-tooling tests; 329 xtask unit tests and 7 integrations pass.
- Formatting, strict all-target/all-feature xtask Clippy, actionlint, whitespace and cargo xtask all pass.
- Hosted native Windows compiler regression, complete required CI, and final tagged signing/install/archive checks remain required before publication.

Owner explicitly authorized repair, tag replacement, and release publication. The existing v0.0.1 tag has not yet been replaced; the release is still a draft. No H3/H4 completion is claimed. Main checks will be allowed to complete.