### PR TITLE
fix(release): bound native compilation stages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,15 +196,16 @@ jobs:
           retention-days: 30
 
   build-daemon-library:
-    name: Release daemon library (macos-15-intel, ${{ matrix.build }})
+    name: Release daemon library (${{ matrix.os }}, ${{ matrix.build }})
     strategy:
       fail-fast: false
       matrix:
         build: [primary, independent]
-    runs-on: macos-15-intel
+        os: [macos-15-intel, windows-2025]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     env:
-      CARGO_BUILD_JOBS: "4"
+      CARGO_BUILD_JOBS: ${{ matrix.os == 'macos-15-intel' && '4' || '2' }}
       PERITUS_RELEASE_BUILD_ROLE: ${{ matrix.build }}
     steps:
       - name: Check out the candidate for this independent library compilation
@@ -218,15 +219,50 @@ jobs:
       - name: Retain this role's same-run candidate-bound libraries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: release-libraries-${{ matrix.build }}-${{ matrix.os }}-peritusd
+          path: target/native-daemon-libraries
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  build-cli-library:
+    name: Release CLI library (macos-15-intel, ${{ matrix.build }})
+    needs: build-daemon-library
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [primary, independent]
+    runs-on: macos-15-intel
+    timeout-minutes: 10
+    env:
+      CARGO_BUILD_JOBS: "4"
+      PERITUS_RELEASE_BUILD_ROLE: ${{ matrix.build }}
+    steps:
+      - name: Check out the same candidate for the CLI library compilation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Restore only this role's original same-run daemon libraries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
           name: release-libraries-${{ matrix.build }}-macos-15-intel-peritusd
           path: target/native-daemon-libraries
+      - name: Compile the CLI library with its own dependency features and no product binary
+        run: cargo run --locked --package xtask -- release-cli-library
+      - name: Retain the CLI libraries and original daemon compilation chain
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-libraries-${{ matrix.build }}-macos-15-intel-peritus
+          path: target/native-cli-libraries
           if-no-files-found: error
           compression-level: 0
           retention-days: 1
 
   build-binary:
     name: Release binary ${{ matrix.target.binary }} (${{ matrix.target.os }}, ${{ matrix.build }})
-    needs: build-daemon-library
+    needs: [build-daemon-library, build-cli-library]
     strategy:
       fail-fast: false
       matrix:
@@ -276,7 +312,7 @@ jobs:
           cargo build --release --locked --package ${{ matrix.target.package }}
           --bin ${{ matrix.target.binary }}
       - name: Compile native Windows x86-64 with the pinned reproducible C compiler
-        if: ${{ matrix.target.os == 'windows-2025' }}
+        if: ${{ matrix.target.os == 'windows-2025' && matrix.target.binary != 'peritusd' }}
         env:
           PERITUS_RELEASE_BINARY: ${{ matrix.target.binary }}
         run: cargo run --locked --package xtask -- release-windows-binary
@@ -285,14 +321,14 @@ jobs:
         run: >-
           cargo rustc --release --locked --package ${{ matrix.target.package }}
           --bin ${{ matrix.target.binary }} -- -C link-arg=/Brepro
-      - name: Restore only this same-run build role's native daemon libraries
-        if: ${{ matrix.target.os == 'macos-15-intel' && (matrix.target.binary == 'peritusd' || matrix.target.binary == 'peritus') }}
+      - name: Restore only this same-run build role's native consumer libraries
+        if: ${{ (matrix.target.os == 'macos-15-intel' && (matrix.target.binary == 'peritusd' || matrix.target.binary == 'peritus')) || (matrix.target.os == 'windows-2025' && matrix.target.binary == 'peritusd') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: release-libraries-${{ matrix.build }}-${{ matrix.target.os }}-peritusd
-          path: target/native-daemon-libraries
+          name: release-libraries-${{ matrix.build }}-${{ matrix.target.os }}-${{ matrix.target.binary }}
+          path: target/native-${{ matrix.target.binary == 'peritus' && 'cli' || 'daemon' }}-libraries
       - name: Verify native library inputs and compile the final daemon binary
-        if: ${{ matrix.target.os == 'macos-15-intel' && matrix.target.binary == 'peritusd' }}
+        if: ${{ (matrix.target.os == 'macos-15-intel' || matrix.target.os == 'windows-2025') && matrix.target.binary == 'peritusd' }}
         env:
           PERITUS_RELEASE_BUILD_ROLE: ${{ matrix.build }}
         run: cargo run --locked --package xtask -- release-daemon-binary
@@ -302,7 +338,7 @@ jobs:
           PERITUS_RELEASE_BUILD_ROLE: ${{ matrix.build }}
         run: cargo run --locked --package xtask -- release-cli-binary
       - name: Retain actual library and binary compilation observations
-        if: ${{ matrix.target.os == 'macos-15-intel' && (matrix.target.binary == 'peritusd' || matrix.target.binary == 'peritus') }}
+        if: ${{ (matrix.target.os == 'macos-15-intel' && (matrix.target.binary == 'peritusd' || matrix.target.binary == 'peritus')) || (matrix.target.os == 'windows-2025' && matrix.target.binary == 'peritusd') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-compile-${{ matrix.build }}-${{ matrix.target.os }}--${{ matrix.target.binary }}
@@ -314,6 +350,52 @@ jobs:
         with:
           name: release-bin-${{ matrix.build }}-${{ matrix.target.os }}--${{ matrix.target.binary }}
           path: target/release/${{ matrix.target.artifact }}
+          if-no-files-found: error
+          retention-days: 30
+
+  check-native-staging:
+    name: Compare previous native staging (${{ matrix.target.os }})
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: build-binary
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { os: macos-15-intel, binary: peritus }
+          - { os: windows-2025, binary: peritusd }
+    runs-on: ${{ matrix.target.os }}
+    timeout-minutes: 10
+    env:
+      CARGO_BUILD_JOBS: ${{ matrix.target.os == 'macos-15-intel' && '4' || '2' }}
+      PERITUS_RELEASE_BUILD_ROLE: primary
+    steps:
+      - name: Check out the exact candidate for a diagnostic previous-path compilation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Restore the actual staged product only for byte comparison
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-bin-primary-${{ matrix.target.os }}--${{ matrix.target.binary }}
+          path: target/staging-candidate
+      - name: Restore the original libraries used by the previous Intel Mac CLI path
+        if: ${{ matrix.target.os == 'macos-15-intel' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-libraries-primary-macos-15-intel-peritusd
+          path: target/native-daemon-libraries
+      - name: Compile and compare the previous path without creating release evidence
+        env:
+          PERITUS_RELEASE_BINARY: ${{ matrix.target.binary }}
+        run: cargo run --locked --package xtask -- release-staging-check
+      - name: Retain diagnostic comparison only, never its product binary
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-staging-check-${{ matrix.target.os }}
+          path: target/native-staging-check.json
           if-no-files-found: error
           retention-days: 30
 
@@ -344,8 +426,8 @@ jobs:
           merge-multiple: true
       - name: Assemble, archive, checksum, and record native package
         run: cargo run --locked --package xtask -- release-package-assemble
-      - name: Restore both matching CLI and daemon compilation records for native assembly
-        if: ${{ matrix.os == 'macos-15-intel' }}
+      - name: Restore the matching staged compilation records for native assembly
+        if: ${{ matrix.os == 'macos-15-intel' || matrix.os == 'windows-2025' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: release-compile-${{ matrix.build }}-${{ matrix.os }}--*

--- a/packaging/native-build.md
+++ b/packaging/native-build.md
@@ -6,20 +6,23 @@ each role's own binaries and requires complete byte-identical archive/checksum
 outputs before release attestation. Manual validation cannot create a release,
 sign packages, or publish. Passing a development run is not final H4 qualification.
 
-## Intel macOS library and binary phases
+## Bounded native library and binary phases
 
 The Intel macOS daemon and CLI exceeded the ten-minute job ceiling even with
-four build jobs. The daemon library producer and each final binary now have
-separate bounded native phases. The other native binary commands, supported platforms, release profile, locked
+four build jobs. The native x86-64 Windows daemon also exceeded that ceiling.
+The daemon library producer and each final binary now have separate bounded
+native phases on these hosts. Intel macOS adds a dedicated CLI-library phase
+between its original daemon libraries and the final CLI binary. The other native binary commands, supported platforms, release profile, locked
 dependencies, and ten-minute limits are unchanged. The binary matrix waits for
-both independent library producers before starting; no role borrows another
+all independent library producers before starting; no role borrows another
 role's compilation.
 
 The existing library target is selected with `cargo build --release --locked
 --package peritus-daemon --lib`. The final phase still runs the corresponding
 `--package peritus-daemon --bin peritusd` build for the daemon, or
 `--package peritus-cli --bin peritus` for the CLI. The CLI retains its own
-dependency features: Cargo recompiles feature-affected libraries when necessary.
+dependency features: `cargo build --release --locked --package peritus-cli --lib`
+recompiles feature-affected libraries in the intermediate stage when necessary.
 This is partial library reuse, not a forced shared feature graph or a promise
 that only the final binary target compiles. Cargo's [target selection](https://doc.rust-lang.org/cargo/commands/cargo-build.html#target-selection)
 does not change the declared release profile.
@@ -34,13 +37,18 @@ cargo xtask release-daemon-library
 cargo xtask release-daemon-binary
 # In a separate fresh checkout at that same absolute path, restore the original
 # library-only artifact again, never the daemon binary consumer's target tree:
+cargo xtask release-cli-library
+# In another fresh checkout, restore only this role's target/native-cli-libraries:
 cargo xtask release-cli-binary
 ```
 
 These commands reject existing compilation/product outputs. They use the fixed
 `target/native-daemon` Cargo directory. Linux can exercise the transfer mechanics
-locally, but Linux timing is not evidence of native macOS capacity. Windows does
-not use this handoff.
+locally, but Linux timing is not evidence of native macOS or Windows capacity.
+Windows uses only the daemon-library and daemon-binary stages, with two build
+jobs, pinned native clang-cl 20.1.8, and the original `cargo rustc ... --bin
+peritusd -- -C link-arg=/Brepro` final command. The actual `.exe` bytes are
+retained; no post-link rewriting or prebuilt executable reuse is allowed.
 
 ## Admission and independence
 
@@ -62,14 +70,18 @@ The library and binary invocations retain distinct real times and identifiers.
 
 Each final phase retains `target/native-peritusd-build.json` or
 `target/native-peritus-build.json` alongside its separately uploaded binary.
-Assembly requires exactly these two same-run, same-role records, bound to their
-respective package and binary, with distinct final invocations and an identical
-original library record. It checks both hashes against the actual archive
-members, not loose package projections. Binary compilation records use schema v2;
-native assembly schema v3 retains both in `binary_compilations`. Other platforms
-retain an empty map. Old daemon-only binary/assembly development observations
-do not qualify a new candidate under this protocol. The daemon library transport
-remains schema v1. The independent comparison remains mandatory.
+Intel macOS assembly requires exactly these two same-run, same-role records,
+bound to their respective package and binary. The CLI library record must retain
+the exact original daemon library as `previous_library`; daemon library records
+must not have a parent. All dependent invocations must be distinct and ordered.
+Windows x86-64 assembly requires exactly its daemon record and rechecks the
+pinned C compiler identity. Assembly checks hashes against actual tar/ZIP
+members, not loose package projections. Library records use schema v2, binary
+records v3, and native assembly v4 retains them in `binary_compilations`.
+Other platforms retain an empty map. Earlier development observations do not
+qualify a new candidate under this protocol. The independent comparison remains
+mandatory. Reruns must include producers and consumers from the same workflow
+attempt; retrying just a consumer against an older attempt is intentionally rejected.
 
 ## Verification
 
@@ -78,3 +90,7 @@ compile-failure, archived-binary, and native workflow boundary regressions.
 Real fresh-source transfer and unsplit-build byte comparison are also required
 before a new workflow is considered ready. Hosted native completion must be
 observed on the exact commit; local fixtures cannot establish its timing.
+Manual dispatch additionally compiles the previous Intel Mac CLI path (from
+its original daemon libraries) and the previous cold Windows daemon path, then
+compares them with the actual staged products. These diagnostic binaries cannot
+enter assembly: only a separate `native-staging-diagnostic` report is uploaded.

--- a/packaging/native_build.py
+++ b/packaging/native_build.py
@@ -15,8 +15,10 @@ ROOT = Path(__file__).resolve().parent.parent
 
 
 def compile_phase(stage, expected):
-    arguments = cargo_arguments(stage, expected["binary"])
+    arguments = cargo_arguments(stage, expected["binary"], expected["environment"].get("system"))
     environment = os.environ.copy()
+    if expected["environment"].get("system") == "Windows":
+        environment["CC_x86_64_pc_windows_msvc"] = expected["environment"]["cc"]["path"]
     environment["CARGO_TARGET_DIR"] = str(ROOT / "target/native-daemon")
     environment["CARGO_BUILD_JOBS"] = str(expected["environment"]["cargo_build_jobs"])
     environment["CARGO_INCREMENTAL"] = "0"
@@ -28,31 +30,45 @@ def compile_phase(stage, expected):
     return observed
 
 
-def library():
-    expected = inputs.binding()
-    tree, bundle = ROOT / "target/native-daemon", ROOT / "target/native-daemon-libraries"
+def library(binary_name="peritusd"):
+    expected = inputs.binding(binary_name)
+    tree, bundle = ROOT / "target/native-daemon", library_directory(binary_name)
     if tree.exists() or tree.is_symlink() or bundle.exists() or bundle.is_symlink():
         raise ValueError("native library compilation requires fresh output directories")
     inputs.normalize_verified_sources(expected["candidate"])
+    previous = None
+    if binary_name == "peritus":
+        previous = transport.restore(library_directory("peritusd"), tree, inputs.daemon_binding(expected))
     observed = compile_phase("library", expected)
-    transport.save(tree, bundle, expected, observed)
+    transport.save(tree, bundle, expected, observed, previous)
+
+
+def library_directory(binary_name):
+    package = transport.binary_package(binary_name).removeprefix("peritus-")
+    return ROOT / f"target/native-{package}-libraries"
 
 
 def binary(binary_name="peritusd"):
     expected = inputs.binding(binary_name)
     tree = ROOT / "target/native-daemon"
-    product = ROOT / "target/release" / binary_name
+    windows = expected["environment"].get("system") == "Windows"
+    filename = binary_name + (".exe" if windows else "")
+    product = ROOT / "target/release" / filename
     record_path = ROOT / "target" / transport.record_filename(binary_name)
     if product.exists() or product.is_symlink() or record_path.exists() or record_path.is_symlink():
         raise ValueError("native final compilation refuses to overwrite a product or record")
     inputs.normalize_verified_sources(expected["candidate"])
-    earlier = transport.restore(ROOT / "target/native-daemon-libraries", tree,
+    earlier = transport.restore(library_directory(binary_name), tree,
                                 inputs.library_binding(expected))
     observed = compile_phase("binary", expected)
-    compiled = transport.regular(tree / "release" / binary_name)
-    if not compiled.stat().st_size or not compiled.stat().st_mode & 0o100:
+    compiled = transport.regular(tree / "release" / filename)
+    if not compiled.stat().st_size or (not windows and not compiled.stat().st_mode & 0o100):
         raise ValueError("native final compilation did not produce its executable binary")
-    record = {"schema_version": 2, "kind": "native-release-binary-compilation",
+    if windows:
+        with compiled.open("rb") as payload:
+            if payload.read(2) != b"MZ":
+                raise ValueError("native Windows compilation did not produce a PE executable")
+    record = {"schema_version": 3, "kind": "native-release-binary-compilation",
               "binding": expected, "library": earlier, "observation": observed,
               "binary": {"sha256": transport.digest(compiled), "byte_length": compiled.stat().st_size}}
     inputs.validate_binary_record(record, expected["candidate"], expected["role"], compiled, binary_name)
@@ -67,11 +83,12 @@ def binary(binary_name="peritusd"):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="phase", required=True)
-    commands.add_parser("library")
+    producer = commands.add_parser("library")
+    producer.add_argument("binary", nargs="?", default="peritusd", choices=tuple(transport.BINARY_PACKAGES))
     consumer = commands.add_parser("binary")
     consumer.add_argument("binary", choices=tuple(transport.BINARY_PACKAGES))
     arguments = parser.parse_args()
     if arguments.phase == "library":
-        library()
+        library(arguments.binary)
     else:
         binary(arguments.binary)

--- a/packaging/native_inputs.py
+++ b/packaging/native_inputs.py
@@ -116,7 +116,15 @@ def normalize_verified_sources(expected):
         raise ValueError("native compilation source changed before timestamp preparation")
     epoch = expected["source_date_epoch"] * 1_000_000_000
     for name in expected["source_files_sha256"]:
-        os.utime(ROOT / name, ns=(epoch, epoch), follow_symlinks=False)
+        path = ROOT / name
+        metadata = path.lstat()
+        if (not stat.S_ISREG(metadata.st_mode)
+                or getattr(metadata, "st_file_attributes", 0) & stat.FILE_ATTRIBUTE_REPARSE_POINT):
+            raise ValueError("native source timestamp preparation requires a regular non-reparse file")
+        # Windows Python does not implement the no-follow keyword. The complete
+        # source inventory was just verified; recheck each entry before timestamping.
+        options = {"follow_symlinks": False} if os.utime in os.supports_follow_symlinks else {}
+        os.utime(path, ns=(epoch, epoch), **options)
 
 
 def observation(started, arguments):

--- a/packaging/native_inputs.py
+++ b/packaging/native_inputs.py
@@ -10,7 +10,8 @@ import time
 import tomllib
 import uuid
 
-from native_transport import binary_package, digest, validate_observation, validate_record
+from native_transport import binary_package, digest, validate_later, validate_observation, validate_record
+import windows_release
 
 ROOT = Path(__file__).resolve().parent.parent
 ROLE_ENV = "PERITUS_RELEASE_BUILD_ROLE"
@@ -52,8 +53,8 @@ def candidate():
 
 
 def environment():
-    if platform.system() not in ("Darwin", "Linux"):
-        raise ValueError("native daemon library handoff requires a Unix build host")
+    if platform.system() not in ("Darwin", "Linux", "Windows"):
+        raise ValueError("unsupported native library build host")
     forbidden = {"RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS", "CARGO_BUILD_RUSTFLAGS",
                  "RUSTC", "CARGO_BUILD_RUSTC", "RUSTC_BOOTSTRAP",
                  "RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER", "CARGO_TARGET_DIR", "CARGO_BUILD_TARGET"}
@@ -66,11 +67,13 @@ def environment():
     jobs = os.environ.get("CARGO_BUILD_JOBS", "2")
     if jobs not in ("1", "2", "3", "4"):
         raise ValueError("native release compilation requires one through four build jobs")
+    compiler = windows_release.compiler_environment()[1] if platform.system() == "Windows" else None
     result = {"system": platform.system(), "machine": platform.machine(),
               "release": platform.release(), "version": platform.version(),
               "rustc": command("rustc", "--version", "--verbose"),
               "rust_sysroot": command("rustc", "--print", "sysroot"),
-              "cargo": command("cargo", "--version"), "cc": command("cc", "--version"),
+              "cargo": command("cargo", "--version"),
+              "cc": compiler if compiler is not None else command("cc", "--version"),
               "image_os": os.environ.get("ImageOS"), "image_version": os.environ.get("ImageVersion"),
               "cargo_build_jobs": int(jobs), "checkout": str(ROOT.resolve()),
               "cargo_home": str(Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo")).resolve()),
@@ -98,7 +101,12 @@ def binding(binary="peritusd"):
 
 
 def library_binding(consumer):
-    """Both consumers require this role's original daemon library compilation."""
+    """The final binary consumes its own package's observed library compilation."""
+    return dict(consumer)
+
+
+def daemon_binding(consumer):
+    """The CLI library stage starts with this role's original daemon libraries."""
     return dict(consumer, package="peritus-daemon", binary="peritusd")
 
 
@@ -128,7 +136,7 @@ def validate_binary_observation(record, expected_candidate, role, observed, bina
     package = binary_package(binary_name)
     if (not isinstance(record, dict) or set(record) != {
             "schema_version", "kind", "binding", "library", "observation", "binary"}
-            or type(record["schema_version"]) is not int or record["schema_version"] != 2
+            or type(record["schema_version"]) is not int or record["schema_version"] != 3
             or record["kind"] != "native-release-binary-compilation"):
         raise ValueError("invalid native binary compilation record")
     bound = record["binding"]
@@ -138,11 +146,11 @@ def validate_binary_observation(record, expected_candidate, role, observed, bina
             or bound["package"] != package or bound["binary"] != binary_name):
         raise ValueError("native binary compilation candidate, role, or consumer differs")
     validate_record(record["library"], library_binding(bound))
-    validate_observation(record["observation"], "binary", binary_name)
+    validate_observation(record["observation"], "binary", binary_name, bound["environment"].get("system"))
     first, last = record["library"]["observation"], record["observation"]
-    if (first["invocation"] == last["invocation"]
-            or first["finished_unix_nanos"] > last["started_unix_nanos"]):
-        raise ValueError("native binary compilation must be a distinct later invocation")
+    validate_later(first, last)
+    if record["library"]["previous_library"] is not None:
+        validate_later(record["library"]["previous_library"]["observation"], last)
     if record["binary"] != observed:
         raise ValueError("native binary compilation record differs from its product bytes")
 

--- a/packaging/native_staging_check.py
+++ b/packaging/native_staging_check.py
@@ -1,0 +1,63 @@
+"""Manual-only byte comparison with the previous native compilation boundaries.
+
+These diagnostic products are never uploaded as release binaries or admitted as
+release compilation records. The workflow supplies the actual staged product.
+"""
+
+import argparse
+import filecmp
+from pathlib import Path
+import time
+
+import native_build
+import native_inputs as inputs
+import native_transport as transport
+import windows_release
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def check(binary):
+    expected = inputs.binding(binary)
+    environment = expected["environment"]
+    host = environment["system"], environment["machine"].lower(), binary
+    if host not in (("Darwin", "x86_64", "peritus"),
+                    ("Windows", "amd64", "peritusd"), ("Windows", "x86_64", "peritusd")):
+        raise ValueError("staging comparison is limited to the changed native compilation paths")
+    windows = environment["system"] == "Windows"
+    filename = binary + (".exe" if windows else "")
+    directory = ROOT / "target/staging-candidate"
+    if (directory.is_symlink() or not directory.is_dir()
+            or {path.name for path in directory.iterdir()} != {filename}):
+        raise ValueError("staging comparison requires exactly the actual same-run staged binary")
+    staged = transport.regular(directory / filename)
+    target = ROOT / ("target/release" if windows else "target/native-daemon")
+    report = ROOT / "target/native-staging-check.json"
+    if target.exists() or target.is_symlink() or report.exists() or report.is_symlink():
+        raise ValueError("previous-path compilation requires fresh diagnostic outputs")
+    inputs.normalize_verified_sources(expected["candidate"])
+    if windows:
+        started = time.time_ns()
+        windows_release.build(binary)
+        observation = inputs.observation(started, transport.cargo_arguments("binary", binary, "Windows"))
+        product = target / filename
+    else:
+        transport.restore(ROOT / "target/native-daemon-libraries", target, inputs.daemon_binding(expected))
+        observation = native_build.compile_phase("binary", expected)
+        product = target / "release" / filename
+    if inputs.binding(binary) != expected:
+        raise ValueError("previous-path inputs changed while Cargo was running")
+    transport.regular(product)
+    identical = bool(staged.stat().st_size and filecmp.cmp(staged, product, shallow=False))
+    inputs.write_record(report, {"schema_version": 1, "kind": "native-staging-diagnostic",
+        "binding": expected, "observation": observation, "byte_identical": identical,
+        "staged_sha256": transport.digest(staged), "previous_path_sha256": transport.digest(product)})
+    if not identical:
+        raise ValueError("staged binary differs from the previous native compilation path")
+    print(f"Staged {filename} is byte-identical to the previous native compilation path", flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("binary", choices=tuple(transport.BINARY_PACKAGES))
+    check(parser.parse_args().binary)

--- a/packaging/native_transport.py
+++ b/packaging/native_transport.py
@@ -17,6 +17,8 @@ MAX_EXPANDED_BYTES = 8 * 1024**3
 MAX_MEMBERS = 100_000
 MAX_RECORD_BYTES = 4 * 1024**2
 BINARY_PACKAGES = {"peritusd": "peritus-daemon", "peritus": "peritus-cli"}
+WINDOWS_DEVICES = {"con", "prn", "aux", "nul", *(f"com{i}" for i in range(1, 10)),
+                   *(f"lpt{i}" for i in range(1, 10))}
 
 
 def binary_package(binary):
@@ -30,12 +32,13 @@ def record_filename(binary):
     return f"native-{binary}-build.json"
 
 
-def cargo_arguments(stage, binary="peritusd"):
+def cargo_arguments(stage, binary="peritusd", system=None):
     if stage not in ("library", "binary"):
         raise ValueError("native compilation phase must be library or binary")
     package = binary_package(binary)
-    if stage == "library" and binary != "peritusd":
-        raise ValueError("the shared native library producer must compile peritus-daemon")
+    if stage == "binary" and system == "Windows":
+        return ["cargo", "rustc", "--release", "--locked", "--package", package,
+                "--bin", binary, "--", "-C", "link-arg=/Brepro"]
     return ["cargo", "build", "--release", "--locked", "--package", package,
             *(["--lib"] if stage == "library" else ["--bin", binary])]
 
@@ -56,14 +59,17 @@ def members(entries):
     for entry in entries:
         name = entry.name.rstrip("/") if entry.isdir() else entry.name
         path = PurePosixPath(name)
-        if (not name or "\\" in name or any(ord(char) < 32 for char in name)
+        if (not name or any(char in name for char in '\\:<>"|?*')
+                or any(ord(char) < 32 for char in name)
+                or any(part.endswith((".", " ")) or part.split(".")[0].casefold() in WINDOWS_DEVICES
+                       for part in path.parts)
                 or path.as_posix() != name or path.is_absolute() or ".." in path.parts
-                or path.parts[0] != "native-daemon" or name in names
+                or path.parts[0] != "native-daemon" or name.casefold() in names
                 or (len(path.parts) == 1 and not entry.isdir())
                 or not (entry.isfile() or entry.isdir()) or entry.mode & 0o7000
                 or entry.size < 0 or not math.isfinite(entry.mtime) or entry.mtime < 0):
             raise ValueError(f"unsafe or duplicate native library archive member: {entry.name}")
-        names.add(name)
+        names.add(name.casefold())
         expanded += entry.size
         result.append(entry)
         if len(result) > MAX_MEMBERS or expanded > MAX_EXPANDED_BYTES:
@@ -73,7 +79,7 @@ def members(entries):
     return result
 
 
-def library_tree(root):
+def library_tree(root, binary="peritusd"):
     if root.name != "native-daemon":
         raise ValueError("native libraries require their fixed target directory")
     tree = native_archive.entries(root)
@@ -86,36 +92,37 @@ def library_tree(root):
         if stat.S_ISREG(mode):
             expanded += path.stat().st_size
         if stat.S_ISREG(mode) and any(
-                path.name == binary or path.name.startswith(binary + "-")
-                or path.name.startswith("bin-" + binary) for binary in BINARY_PACKAGES):
+                path.name.casefold() in (binary, binary + ".exe") or path.name.casefold().startswith(binary + "-")
+                or path.name.casefold().startswith("bin-" + binary) for binary in BINARY_PACKAGES):
             raise ValueError("library compilation cannot contain a prebuilt product binary")
     if expanded > MAX_EXPANDED_BYTES:
         raise ValueError("native library tree exceeds its expanded-byte bound")
-    library = root / "release/libperitus_daemon.rlib"
-    candidates = list((root / "release/deps").glob("libperitus_daemon-*.rlib"))
+    crate = binary_package(binary).replace("-", "_")
+    library = root / f"release/lib{crate}.rlib"
+    candidates = list((root / "release/deps").glob(f"lib{crate}-*.rlib"))
     if not library.is_file() or not regular(library).stat().st_size or len(candidates) != 1:
-        raise ValueError("native compilation requires exactly one complete daemon library")
+        raise ValueError("native compilation requires exactly one complete consumer library")
     if not regular(candidates[0]).stat().st_size:
         raise ValueError("native daemon dependency library is empty")
     return tree
 
 
-def validate_observation(observation, stage, binary="peritusd"):
+def validate_observation(observation, stage, binary="peritusd", system=None):
     if (not isinstance(observation, dict) or not observation.get("host")
             or not observation.get("invocation")
             or type(observation.get("started_unix_nanos")) is not int
             or type(observation.get("finished_unix_nanos")) is not int
             or not 0 < observation["started_unix_nanos"] <= observation["finished_unix_nanos"]
-            or observation.get("command") != cargo_arguments(stage, binary)):
+            or observation.get("command") != cargo_arguments(stage, binary, system)):
         raise ValueError("native compilation observation is incomplete or unordered")
 
 
 def validate_record(record, expected):
     if (not isinstance(record, dict) or set(record) != {
             "schema_version", "kind", "binding", "observation",
-            "archive_byte_length", "archive_sha256"}
-            or type(record["schema_version"]) is not int or record["schema_version"] != 1
-            or record["kind"] != "native-daemon-library-compilation"
+            "archive_byte_length", "archive_sha256", "previous_library"}
+            or type(record["schema_version"]) is not int or record["schema_version"] != 2
+            or record["kind"] != "native-release-library-compilation"
             or record["binding"] != expected):
         raise ValueError("native library binding differs from this candidate, role, or environment")
     if (type(record["archive_byte_length"]) is not int
@@ -123,12 +130,26 @@ def validate_record(record, expected):
             or not isinstance(record["archive_sha256"], str)
             or not re.fullmatch(r"[0-9a-f]{64}", record["archive_sha256"])):
         raise ValueError("native library archive identity is invalid")
-    validate_observation(record["observation"], "library")
+    binary = expected["binary"]
+    validate_observation(record["observation"], "library", binary)
+    previous = record["previous_library"]
+    if binary == "peritusd":
+        if previous is not None:
+            raise ValueError("daemon library compilation cannot have a previous library")
+    else:
+        validate_record(previous, dict(expected, package="peritus-daemon", binary="peritusd"))
+        validate_later(previous["observation"], record["observation"])
 
 
-def save(root, directory, binding, observation):
-    tree = library_tree(root)
-    validate_observation(observation, "library")
+def validate_later(first, last):
+    if (first["invocation"] == last["invocation"]
+            or first["finished_unix_nanos"] > last["started_unix_nanos"]):
+        raise ValueError("native compilation must be a distinct later invocation")
+
+
+def save(root, directory, binding, observation, previous_library=None):
+    tree = library_tree(root, binding["binary"])
+    validate_observation(observation, "library", binding["binary"])
     directory.mkdir(parents=True)
     archive = directory / ARCHIVE
     with tarfile.open(archive, "x:gz", compresslevel=1, dereference=True) as output:
@@ -142,8 +163,9 @@ def save(root, directory, binding, observation):
                     output.addfile(info, payload)
             else:
                 output.addfile(info)
-    record = {"schema_version": 1, "kind": "native-daemon-library-compilation",
+    record = {"schema_version": 2, "kind": "native-release-library-compilation",
               "binding": binding, "observation": observation,
+              "previous_library": previous_library,
               "archive_byte_length": archive.stat().st_size, "archive_sha256": digest(archive)}
     validate_record(record, binding)
     with (directory / RECORD).open("x", newline="\n") as output:
@@ -172,5 +194,5 @@ def restore(directory, destination, expected):
     with tarfile.open(archive, "r:gz") as source:
         inventory = members(source)
         source.extractall(destination.parent, members=inventory, filter="data")
-    library_tree(destination)
+    library_tree(destination, expected["binary"])
     return record

--- a/packaging/rebuild.py
+++ b/packaging/rebuild.py
@@ -21,6 +21,7 @@ import time
 import tomllib
 import uuid
 import zlib
+import zipfile
 
 import native_inputs
 import native_transport
@@ -29,6 +30,14 @@ ROOT = Path(__file__).resolve().parent.parent
 OBSERVATION = "peritus-native-build.json"
 PACKAGE_RECORD = "peritus-native-package.json"
 INTEL_MAC_ARCHIVE = "dist/peritus-macos-x86_64.tar.gz"
+WINDOWS_ARCHIVE = "dist/peritus-windows-x86_64.zip"
+
+
+def compilation_names(package):
+    target = package["archive"].replace("\\", "/")
+    if target == INTEL_MAC_ARCHIVE:
+        return set(native_transport.BINARY_PACKAGES)
+    return {"peritusd"} if target == WINDOWS_ARCHIVE else set()
 
 
 def regular(path):
@@ -98,7 +107,7 @@ def record(directory, role):
     package, artifacts = outputs(directory)
     compilations = binary_compilations(directory, package, role)
     observation = {
-        "schema_version": 3, "kind": "native-release-assembly", "role": role,
+        "schema_version": 4, "kind": "native-release-assembly", "role": role,
         "invocation": str(uuid.uuid4()), "observed_unix_nanos": time.time_ns(),
         "candidate": candidate(), "artifacts": artifacts, "package_record": package,
         "binary_compilations": compilations,
@@ -125,7 +134,7 @@ def record(directory, role):
 def load(directory, role):
     observation = json.loads(regular(directory / OBSERVATION).read_bytes())
     package, artifacts = outputs(directory)
-    if (observation["schema_version"] != 3 or observation["kind"] != "native-release-assembly"
+    if (observation["schema_version"] != 4 or observation["kind"] != "native-release-assembly"
             or observation["role"] != role or observation["artifacts"] != artifacts
             or observation["package_record"] != package):
         raise ValueError("native build observation does not match its retained outputs")
@@ -135,16 +144,16 @@ def load(directory, role):
 
 def binary_compilations(directory, package, role):
     source = ROOT / "target/native-compile-record"
-    required = package["archive"].replace("\\", "/") == INTEL_MAC_ARCHIVE
+    required = compilation_names(package)
     if not required:
         if source.exists() or source.is_symlink():
             raise ValueError("unexpected binary compilation evidence on this native target")
         return {}
     names = {binary: native_transport.record_filename(binary)
-             for binary in native_transport.BINARY_PACKAGES}
+             for binary in required}
     if (source.is_symlink() or not source.is_dir()
             or {path.name for path in source.iterdir()} != set(names.values())):
-        raise ValueError("native compilation evidence requires exactly the CLI and daemon records")
+        raise ValueError("native compilation evidence requires exactly this target's staged binary records")
     records = {}
     for binary, name in names.items():
         path = regular(source / name)
@@ -156,38 +165,46 @@ def binary_compilations(directory, package, role):
 
 
 def validate_binary_compilations(records, directory, package, role):
-    required = package["archive"].replace("\\", "/") == INTEL_MAC_ARCHIVE
-    names = set(native_transport.BINARY_PACKAGES) if required else set()
+    names = compilation_names(package)
     if not isinstance(records, dict) or set(records) != names:
         raise ValueError("native binary compilation inventory differs from this archive target")
     if not names:
         return
-    observed = archived_binaries(directory / PurePosixPath(package["archive"]).name)
+    archive_path = package["archive"].replace("\\", "/")
+    windows = archive_path == WINDOWS_ARCHIVE
+    observed = archived_binaries(directory / PurePosixPath(archive_path).name, windows)
     candidate_inputs = native_inputs.candidate()
     rustc = command("rustc", "--version", "--verbose")
     for name, record in records.items():
         native_inputs.validate_binary_observation(record, candidate_inputs, role, observed[name], name)
-        validate_compilation_environment(record["binding"], rustc)
-    daemon, cli = records["peritusd"], records["peritus"]
-    if (daemon["library"] != cli["library"]
-            or daemon["observation"]["invocation"] == cli["observation"]["invocation"]):
-        raise ValueError("native CLI and daemon must have distinct invocations from the same role's library")
+        validate_compilation_environment(record["binding"], rustc, windows)
+    if not windows:
+        daemon, cli = records["peritusd"], records["peritus"]
+        if (daemon["library"] != cli["library"]["previous_library"]
+                or daemon["observation"]["invocation"] in (
+                    cli["observation"]["invocation"], cli["library"]["observation"]["invocation"])):
+            raise ValueError("native CLI and daemon must have distinct invocations from the same role's library")
 
 
-def validate_compilation_environment(bound, rustc):
-    if (bound["environment"]["system"] != "Darwin"
-            or bound["environment"]["machine"] != "x86_64"
+def validate_compilation_environment(bound, rustc, windows=False):
+    machines = ("amd64", "x86_64") if windows else ("x86_64",)
+    if (bound["environment"]["system"] != ("Windows" if windows else "Darwin")
+            or bound["environment"]["machine"].lower() not in machines
             or bound["environment"]["rustc"] != rustc
             or bound["environment"]["image_version"] != os.environ.get("ImageVersion")):
         raise ValueError("native binary compilation environment differs from native assembly")
+    if windows and bound["environment"]["cc"] != native_inputs.windows_release.compiler_environment()[1]:
+        raise ValueError("native Windows compilation C compiler differs from native assembly")
     if os.environ.get("GITHUB_ACTIONS") == "true":
         workflow = {key: os.environ.get(key) for key in native_inputs.WORKFLOW_KEYS}
         if not all(workflow.values()) or bound["workflow"] != workflow:
             raise ValueError("native binary compilation differs from this assembly's workflow run")
 
 
-def archived_binaries(archive):
+def archived_binaries(archive, windows=False):
     """Inspect the shipped bytes, never the untrusted loose package projection."""
+    if windows:
+        return archived_windows_daemon(archive)
     wanted = {f"peritus-macos-x86_64/bin/{name}": name for name in native_transport.BINARY_PACKAGES}
     result, expanded, count = {}, 0, 0
     with tarfile.open(regular(archive), "r:gz") as source:
@@ -207,6 +224,25 @@ def archived_binaries(archive):
     if set(result) != set(wanted.values()):
         raise ValueError("native archive is missing a compiled CLI or daemon")
     return result
+
+
+def archived_windows_daemon(archive):
+    wanted = "peritus-windows-x86_64/bin/peritusd.exe"
+    with zipfile.ZipFile(regular(archive)) as source:
+        entries = source.infolist()
+        if len(entries) > 10_000 or sum(entry.file_size for entry in entries) > 1024**3:
+            raise ValueError("native archive exceeds its inspection bound")
+        products = [entry for entry in entries if entry.filename == wanted]
+        if len(products) != 1:
+            raise ValueError("native archive requires exactly one Windows daemon")
+        entry = products[0]
+        mode = entry.external_attr >> 16
+        if (entry.is_dir() or stat.S_IFMT(mode) not in (0, stat.S_IFREG)
+                or not 0 < entry.file_size <= 256 * 1024**2):
+            raise ValueError("native archive requires one nonempty regular Windows daemon")
+        with source.open(entry) as binary:
+            digest_value = hashlib.file_digest(binary, "sha256").hexdigest()
+        return {"peritusd": {"byte_length": entry.file_size, "sha256": digest_value}}
 
 
 def compare(first, second, report):

--- a/packaging/test_native_build.py
+++ b/packaging/test_native_build.py
@@ -243,6 +243,52 @@ class WindowsNativeBuildTests(NativeBuildFixture):
 
 
 class NativeInputTests(unittest.TestCase):
+    def test_verified_regular_source_timestamps_are_normalized_on_this_host(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "fixture.txt"
+            source.write_bytes(b"explicit fixture source")
+            expected = {"source_date_epoch": 2, "source_files_sha256": {source.name: transport.digest(source)}}
+            with patch.object(inputs, "ROOT", root), patch.object(inputs, "candidate", return_value=expected):
+                inputs.normalize_verified_sources(expected)
+            self.assertEqual(source.stat().st_mtime_ns, 2_000_000_000)
+            self.assertEqual(transport.digest(source), expected["source_files_sha256"][source.name])
+
+    def test_unsupported_no_follow_option_is_not_passed_to_the_native_timestamp_api(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "fixture.txt"
+            source.write_bytes(b"explicit fixture source")
+            expected = {"source_date_epoch": 2, "source_files_sha256": {source.name: transport.digest(source)}}
+            with patch.object(inputs, "ROOT", root), patch.object(inputs, "candidate", return_value=expected), \
+                    patch.object(inputs.os, "supports_follow_symlinks", set()), \
+                    patch.object(inputs.os, "utime") as timestamp:
+                inputs.normalize_verified_sources(expected)
+            timestamp.assert_called_once_with(source, ns=(2_000_000_000, 2_000_000_000))
+
+    @unittest.skipIf(os.name == "nt", "Windows symlink creation requires a host privilege")
+    def test_missing_no_follow_support_does_not_admit_a_symlink_as_source(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "target.txt").write_bytes(b"preserve source")
+            (root / "link.txt").symlink_to("target.txt")
+            expected = {"source_date_epoch": 2, "source_files_sha256": {"link.txt": "fixture"}}
+            with patch.object(inputs, "ROOT", root), patch.object(inputs, "candidate", return_value=expected), \
+                    patch.object(inputs.os, "supports_follow_symlinks", set()), \
+                    patch.object(inputs.os, "utime") as timestamp, self.assertRaises(ValueError):
+                inputs.normalize_verified_sources(expected)
+            timestamp.assert_not_called()
+
+    def test_windows_reparse_file_cannot_be_timestamped_even_when_its_mode_is_regular(self):
+        expected = {"source_date_epoch": 2, "source_files_sha256": {"fixture.txt": "fixture"}}
+        metadata = unittest.mock.Mock(st_mode=0o100644, st_file_attributes=inputs.stat.FILE_ATTRIBUTE_REPARSE_POINT)
+        with patch.object(inputs, "candidate", return_value=expected), \
+                patch.object(Path, "lstat", return_value=metadata), \
+                patch.object(inputs.os, "supports_follow_symlinks", set()), \
+                patch.object(inputs.os, "utime") as timestamp, self.assertRaises(ValueError):
+            inputs.normalize_verified_sources(expected)
+        timestamp.assert_not_called()
+
     def test_windows_environment_records_verified_native_compiler_instead_of_ambient_cc(self):
         compiler = {"path": "fixture-clang-cl", "version": "fixture-version", "sha256": "f" * 64}
         with patch.object(inputs.platform, "system", return_value="Windows"), \

--- a/packaging/test_native_build.py
+++ b/packaging/test_native_build.py
@@ -16,8 +16,7 @@ import native_inputs as inputs
 import native_transport as transport
 
 
-@unittest.skipUnless(os.name == "posix", "native daemon handoff executes only on Unix hosts")
-class NativeBuildTests(unittest.TestCase):
+class NativeBuildFixture(unittest.TestCase):
     def setUp(self):
         self.resources = ExitStack()
         self.addCleanup(self.resources.close)
@@ -38,10 +37,11 @@ class NativeBuildTests(unittest.TestCase):
         self.assertEqual(arguments[:5], ["cargo", "build", "--release", "--locked", "--package"])
         target = self.root / "target/native-daemon/release"
         if arguments[6:] == ["--lib"]:
-            self.assertEqual(arguments[5], "peritus-daemon")
-            (target / "deps").mkdir(parents=True)
-            (target / "libperitus_daemon.rlib").write_bytes(b"fixture library")
-            (target / "deps/libperitus_daemon-fixture.rlib").write_bytes(b"fixture library")
+            self.assertIn(arguments[5], ("peritus-daemon", "peritus-cli"))
+            crate = arguments[5].replace("-", "_")
+            (target / "deps").mkdir(parents=True, exist_ok=True)
+            (target / f"lib{crate}.rlib").write_bytes(b"fixture library")
+            (target / f"deps/lib{crate}-fixture.rlib").write_bytes(b"fixture library")
         else:
             binary = arguments[7]
             self.assertIn(binary, ("peritusd", "peritus"))
@@ -56,6 +56,18 @@ class NativeBuildTests(unittest.TestCase):
             build.library()
         shutil.move(self.root / "target/native-daemon", self.root / "target/retained-producer")
 
+    def prepare_cli(self):
+        self.prepare()
+        self.binding.return_value = dict(self.bound, package="peritus-cli", binary="peritus")
+        with patch.object(build.subprocess, "run", side_effect=self.fake_cargo) as cargo:
+            build.library("peritus")
+        self.assertEqual(cargo.call_count, 1)
+        self.assertFalse((self.root / "target/native-daemon/release/peritus").exists())
+        shutil.move(self.root / "target/native-daemon", self.root / "target/retained-cli-producer")
+
+
+@unittest.skipUnless(os.name == "posix", "Unix executable-mode fixtures require a Unix filesystem")
+class NativeBuildTests(NativeBuildFixture):
     def test_binary_is_actually_compiled_and_its_distinct_observation_binds_the_bytes(self):
         self.prepare()
         with patch.object(build.subprocess, "run", side_effect=self.fake_cargo) as cargo:
@@ -119,7 +131,7 @@ class NativeBuildTests(unittest.TestCase):
             build.cargo_arguments("unknown")
 
     def test_cli_compilation_retains_its_own_command_and_original_same_role_library(self):
-        self.prepare()
+        self.prepare_cli()
         consumer = dict(self.bound, package="peritus-cli", binary="peritus")
         self.binding.return_value = consumer
         with patch.object(build.subprocess, "run", side_effect=self.fake_cargo) as cargo:
@@ -129,7 +141,8 @@ class NativeBuildTests(unittest.TestCase):
         record = json.loads((self.root / "target/native-peritus-build.json").read_bytes())
         inputs.validate_binary_record(record, self.bound["candidate"], "primary", product, "peritus")
         self.assertEqual(record["binding"], consumer)
-        self.assertEqual(record["library"]["binding"], self.bound)
+        self.assertEqual(record["library"]["binding"], consumer)
+        self.assertEqual(record["library"]["previous_library"]["binding"], self.bound)
         self.assertEqual(record["observation"]["command"],
                          ["cargo", "build", "--release", "--locked", "--package", "peritus-cli", "--bin", "peritus"])
         self.assertFalse((self.root / "target/release/peritusd").exists())
@@ -146,14 +159,14 @@ class NativeBuildTests(unittest.TestCase):
             elif fault == "library-role":
                 altered["library"]["binding"]["role"] = "independent"
             elif fault == "library-package":
-                altered["library"]["binding"]["package"] = "peritus-cli"
+                altered["library"]["binding"]["package"] = "peritus-daemon"
             else:
                 altered["schema_version"] = 1
             with self.subTest(fault=fault), self.assertRaises(ValueError):
                 inputs.validate_binary_record(altered, self.bound["candidate"], "primary", product, "peritus")
 
     def test_failed_cli_compilation_cannot_create_a_product_or_success_record(self):
-        self.prepare()
+        self.prepare_cli()
         self.binding.return_value = dict(self.bound, package="peritus-cli", binary="peritus")
         failure = subprocess.CalledProcessError(1, ["fixture cargo"])
         with patch.object(build.subprocess, "run", side_effect=failure), self.assertRaises(subprocess.CalledProcessError):
@@ -161,8 +174,87 @@ class NativeBuildTests(unittest.TestCase):
         self.assertFalse((self.root / "target/native-peritus-build.json").exists())
         self.assertFalse((self.root / "target/release/peritus").exists())
 
+    def test_cli_parent_identity_order_and_attempt_are_mandatory_before_final_cargo(self):
+        self.prepare_cli()
+        path = self.root / "target/native-cli-libraries/libraries.json"
+        original = json.loads(path.read_bytes())
+        for fault in ("missing", "role", "attempt", "recursive", "order", "invocation", "old-schema"):
+            changed = copy.deepcopy(original)
+            parent = changed["previous_library"]
+            if fault == "missing":
+                changed["previous_library"] = None
+            elif fault == "role":
+                parent["binding"]["role"] = "independent"
+            elif fault == "attempt":
+                parent["binding"]["workflow"] = {"GITHUB_RUN_ATTEMPT": "2"}
+            elif fault == "recursive":
+                parent["previous_library"] = copy.deepcopy(parent)
+            elif fault == "order":
+                changed["observation"]["started_unix_nanos"] = 1
+            elif fault == "invocation":
+                changed["observation"]["invocation"] = parent["observation"]["invocation"]
+            else:
+                changed["schema_version"] = 1
+            path.write_text(json.dumps(changed))
+            with self.subTest(fault=fault), patch.object(build.subprocess, "run") as cargo, \
+                    self.assertRaises(ValueError):
+                build.binary("peritus")
+            cargo.assert_not_called()
+            self.assertFalse((self.root / "target/native-daemon").exists())
+            self.assertFalse((self.root / "target/native-peritus-build.json").exists())
+        path.write_text(json.dumps(original))
+
+
+class WindowsNativeBuildTests(NativeBuildFixture):
+    def test_windows_daemon_uses_pinned_compiler_and_brepro_in_a_distinct_final_invocation(self):
+        self.bound["environment"].update(system="Windows", cc={"path": "fixture-clang-cl"})
+        self.prepare()
+
+        def windows_cargo(arguments, **kwargs):
+            self.assertEqual(arguments, transport.cargo_arguments("binary", "peritusd", "Windows"))
+            self.assertEqual(kwargs["env"]["CC_x86_64_pc_windows_msvc"], "fixture-clang-cl")
+            self.assertTrue(kwargs["check"])
+            (self.root / "target/native-daemon/release/peritusd.exe").write_bytes(b"MZ explicit fixture")
+
+        with patch.object(build.subprocess, "run", side_effect=windows_cargo) as cargo:
+            build.binary()
+        cargo.assert_called_once()
+        product = self.root / "target/release/peritusd.exe"
+        record = json.loads((self.root / "target/native-peritusd-build.json").read_bytes())
+        inputs.validate_binary_record(record, self.bound["candidate"], "primary", product)
+        self.assertEqual(record["library"]["binding"]["environment"]["cc"], {"path": "fixture-clang-cl"})
+        self.assertFalse((self.root / "target/release/peritusd").exists())
+        changed = copy.deepcopy(record)
+        changed["observation"]["command"] = transport.cargo_arguments("binary", "peritusd")
+        with self.assertRaises(ValueError):
+            inputs.validate_binary_record(changed, self.bound["candidate"], "primary", product)
+
+    def test_windows_non_executable_output_cannot_emit_a_success_record(self):
+        self.bound["environment"].update(system="Windows", cc={"path": "fixture-clang-cl"})
+        self.prepare()
+
+        def invalid_cargo(*_args, **_kwargs):
+            (self.root / "target/native-daemon/release/peritusd.exe").write_bytes(b"not a PE image")
+
+        with patch.object(build.subprocess, "run", side_effect=invalid_cargo), self.assertRaises(ValueError):
+            build.binary()
+        self.assertFalse((self.root / "target/release/peritusd.exe").exists())
+        self.assertFalse((self.root / "target/native-peritusd-build.json").exists())
+
 
 class NativeInputTests(unittest.TestCase):
+    def test_windows_environment_records_verified_native_compiler_instead_of_ambient_cc(self):
+        compiler = {"path": "fixture-clang-cl", "version": "fixture-version", "sha256": "f" * 64}
+        with patch.object(inputs.platform, "system", return_value="Windows"), \
+                patch.object(inputs.platform, "machine", return_value="AMD64"), \
+                patch.object(inputs.windows_release, "compiler_environment", return_value=({}, compiler)), \
+                patch.object(inputs, "command", return_value="fixture") as command, \
+                patch.dict(os.environ, {}, clear=True):
+            observed = inputs.environment()
+        self.assertEqual(observed["cc"], compiler)
+        self.assertEqual(observed["system"], "Windows")
+        self.assertNotIn(unittest.mock.call("cc", "--version"), command.call_args_list)
+
     def test_consumer_mapping_is_closed_before_source_or_environment_commands(self):
         for binary in ("", "unknown", "../peritus", "peritus; exit 0", None, []):
             with self.subTest(binary=binary), patch.object(inputs, "command") as command:
@@ -173,13 +265,13 @@ class NativeInputTests(unittest.TestCase):
                     build.cargo_arguments("binary", binary)
                 with self.assertRaises(ValueError):
                     transport.record_filename(binary)
-        with self.assertRaises(ValueError):
-            build.cargo_arguments("library", "peritus")
+        self.assertEqual(build.cargo_arguments("library", "peritus")[-3:], ["--package", "peritus-cli", "--lib"])
         with patch.object(inputs, "candidate", return_value={"fixture": True}), \
                 patch.object(inputs, "environment", return_value={"fixture": True}), \
                 patch.dict(os.environ, {inputs.ROLE_ENV: "primary"}, clear=True):
             self.assertEqual(inputs.binding("peritus")["package"], "peritus-cli")
-            self.assertEqual(inputs.library_binding(inputs.binding("peritus")), inputs.binding("peritusd"))
+            self.assertEqual(inputs.library_binding(inputs.binding("peritus")), inputs.binding("peritus"))
+            self.assertEqual(inputs.daemon_binding(inputs.binding("peritus")), inputs.binding("peritusd"))
 
     def test_roles_and_complete_workflow_identity_are_required(self):
         with patch.object(inputs, "candidate", return_value={"fixture": True}), \

--- a/packaging/test_native_build.py
+++ b/packaging/test_native_build.py
@@ -295,6 +295,7 @@ class NativeInputTests(unittest.TestCase):
                 patch.object(inputs.platform, "machine", return_value="AMD64"), \
                 patch.object(inputs.windows_release, "compiler_environment", return_value=({}, compiler)), \
                 patch.object(inputs, "command", return_value="fixture") as command, \
+                patch.object(Path, "home", return_value=Path("fixture-user")), \
                 patch.dict(os.environ, {}, clear=True):
             observed = inputs.environment()
         self.assertEqual(observed["cc"], compiler)

--- a/packaging/test_native_evidence.py
+++ b/packaging/test_native_evidence.py
@@ -6,10 +6,13 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import stat
 import tarfile
 import tempfile
 import unittest
+import warnings
 from unittest.mock import patch
+import zipfile
 
 import archive
 import native_inputs
@@ -28,15 +31,19 @@ class NativeEvidenceTests(unittest.TestCase):
         self.resources.enter_context(patch.object(rebuild, "candidate", return_value=self.candidate))
         self.resources.enter_context(patch.object(native_inputs, "candidate", return_value=self.candidate))
         self.resources.enter_context(patch.dict(os.environ, {"ImageVersion": "fixture-image"}, clear=True))
+        self.compiler = {"path": "fixture-clang-cl", "version": "fixture-version", "sha256": "f" * 64}
+        self.resources.enter_context(patch.object(native_inputs.windows_release, "compiler_environment",
+                                                return_value=({}, self.compiler)))
 
-    def fixture(self, payload=b"non-release daemon fixture"):
+    def fixture(self, payload=b"non-release daemon fixture", windows=False):
         directory = self.root / "dist"
-        loose = directory / "peritus-macos-x86_64"
+        package_name = "peritus-windows-x86_64" if windows else "peritus-macos-x86_64"
+        loose = directory / package_name
         (loose / "bin").mkdir(parents=True)
         payloads = {"peritusd": payload, "peritus": b"non-release CLI fixture"}
         for binary, content in payloads.items():
-            (loose / "bin" / binary).write_bytes(content)
-        name = "peritus-macos-x86_64.tar.gz"
+            (loose / "bin" / (binary + (".exe" if windows else ""))).write_bytes(content)
+        name = package_name + (".zip" if windows else ".tar.gz")
         archive.archive_tree(loose, directory / name, 1)
         (directory / (name + ".sha256")).write_bytes(
             rebuild.digest(directory / name).encode("ascii") + b"\n")
@@ -48,8 +55,9 @@ class NativeEvidenceTests(unittest.TestCase):
                  "package": "peritus-daemon", "binary": "peritusd",
                  "environment": {"system": "Darwin", "machine": "x86_64",
                                  "rustc": "fixture rustc", "image_version": "fixture-image"}}
-        record = {"schema_version": 2, "kind": "native-release-binary-compilation", "binding": bound,
-                  "library": {"schema_version": 1, "kind": "native-daemon-library-compilation",
+        record = {"schema_version": 3, "kind": "native-release-binary-compilation", "binding": bound,
+                  "library": {"schema_version": 2, "kind": "native-release-library-compilation",
+                              "previous_library": None,
                               "binding": copy.deepcopy(bound), "archive_byte_length": 1,
                               "archive_sha256": "0" * 64,
                               "observation": {"host": "fixture", "invocation": "fixture-library",
@@ -62,10 +70,23 @@ class NativeEvidenceTests(unittest.TestCase):
                                               "--package", "peritus-daemon", "--bin", "peritusd"]},
                   "binary": {"sha256": hashlib.sha256(payload).hexdigest(), "byte_length": len(payload)}}
         evidence, records = {}, {}
+        if windows:
+            bound["environment"].update(system="Windows", machine="AMD64", cc=self.compiler)
+            record["library"]["binding"] = copy.deepcopy(bound)
         for binary, content in payloads.items():
+            if windows and binary != "peritusd":
+                continue
             observed = copy.deepcopy(record)
             observed["binding"].update(binary=binary, package=native_transport.binary_package(binary))
-            observed["observation"]["command"] = native_transport.cargo_arguments("binary", binary)
+            if binary == "peritus":
+                observed["library"] = dict(copy.deepcopy(record["library"]),
+                    binding=copy.deepcopy(observed["binding"]), previous_library=copy.deepcopy(record["library"]),
+                    observation={"host": "fixture", "invocation": "fixture-cli-library",
+                                 "started_unix_nanos": 3, "finished_unix_nanos": 4,
+                                 "command": native_transport.cargo_arguments("library", binary)})
+                observed["observation"].update(started_unix_nanos=5, finished_unix_nanos=6)
+            observed["observation"]["command"] = native_transport.cargo_arguments(
+                "binary", binary, "Windows" if windows else "Darwin")
             observed["observation"]["invocation"] = f"fixture-binary-{binary}"
             observed["binary"] = {"sha256": hashlib.sha256(content).hexdigest(), "byte_length": len(content)}
             path = self.root / "target/native-compile-record" / native_transport.record_filename(binary)
@@ -73,6 +94,61 @@ class NativeEvidenceTests(unittest.TestCase):
             path.write_text(json.dumps(observed))
             evidence[binary], records[binary] = path, observed
         return directory, evidence, records
+
+    def test_windows_zip_bytes_and_pinned_compiler_are_bound_to_retained_daemon_stages(self):
+        directory, _, records = self.fixture(windows=True)
+        rebuild.record(directory, "primary")
+        self.assertEqual(rebuild.load(directory, "primary")["binary_compilations"], records)
+        loose = directory / "peritus-windows-x86_64/bin/peritusd.exe"
+        loose.write_bytes(b"loose file is not the shipped binary")
+        self.assertEqual(rebuild.load(directory, "primary")["binary_compilations"], records)
+        compiler = dict(self.compiler, sha256="0" * 64)
+        with patch.object(native_inputs.windows_release, "compiler_environment", return_value=({}, compiler)), \
+                self.assertRaisesRegex(ValueError, "C compiler"):
+            rebuild.load(directory, "primary")
+
+    def test_windows_missing_record_wrong_bytes_attempt_or_command_fails_closed(self):
+        directory, evidence, records = self.fixture(windows=True)
+        original = records["peritusd"]
+        path = evidence["peritusd"]
+        for fault in ("missing", "bytes", "attempt", "command", "schema"):
+            changed = copy.deepcopy(original)
+            if fault == "bytes":
+                changed["binary"]["sha256"] = "0" * 64
+            elif fault == "attempt":
+                changed["library"]["binding"]["workflow"] = {"GITHUB_RUN_ATTEMPT": "2"}
+            elif fault == "command":
+                changed["observation"]["command"] = native_transport.cargo_arguments("binary")
+            elif fault == "schema":
+                changed["schema_version"] = 2
+            path.write_text(json.dumps(changed))
+            if fault == "missing":
+                path.unlink()
+            with self.subTest(fault=fault), self.assertRaises(ValueError):
+                rebuild.record(directory, "primary")
+            self.assertFalse((directory / rebuild.OBSERVATION).exists())
+        path.write_text(json.dumps(original))
+
+    def test_windows_zip_duplicate_link_empty_and_missing_daemon_are_rejected(self):
+        target = self.root / "bad.zip"
+        wanted = "peritus-windows-x86_64/bin/peritusd.exe"
+        for fault in ("duplicate", "link", "empty", "missing"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                with zipfile.ZipFile(target, "w") as output:
+                    if fault == "duplicate":
+                        output.writestr(wanted, b"fixture")
+                        output.writestr(wanted, b"fixture")
+                    elif fault == "link":
+                        info = zipfile.ZipInfo(wanted)
+                        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+                        output.writestr(info, b"somewhere")
+                    elif fault == "empty":
+                        output.writestr(wanted, b"")
+                    else:
+                        output.writestr("peritusd.exe", b"wrong path")
+            with self.subTest(fault=fault), self.assertRaises(ValueError):
+                rebuild.archived_binaries(target, windows=True)
 
     def test_checksum_fixture_is_byte_exact_under_windows_text_translation(self):
         write_text = Path.write_text
@@ -96,7 +172,7 @@ class NativeEvidenceTests(unittest.TestCase):
         directory, _, records = self.fixture()
         rebuild.record(directory, "primary")
         retained = rebuild.load(directory, "primary")
-        self.assertEqual(retained["schema_version"], 3)
+        self.assertEqual(retained["schema_version"], 4)
         self.assertEqual(retained["binary_compilations"], records)
 
     def test_a_loose_projection_cannot_substitute_for_the_archived_binary(self):
@@ -176,13 +252,13 @@ class NativeEvidenceTests(unittest.TestCase):
             elif fault == "missing-cli":
                 del altered["peritus"]
             elif fault == "library":
-                altered["peritus"]["library"]["observation"]["invocation"] = "another-library"
+                altered["peritus"]["library"]["previous_library"]["observation"]["invocation"] = "another-library"
             else:
                 altered["peritus"]["observation"]["invocation"] = altered["peritusd"]["observation"]["invocation"]
             with self.subTest(fault=fault), self.assertRaises(ValueError):
                 rebuild.validate_binary_compilations(altered, directory, package, "primary")
         (evidence["peritus"].parent / "unaccounted.json").write_text("{}")
-        with self.assertRaisesRegex(ValueError, "exactly the CLI and daemon"):
+        with self.assertRaisesRegex(ValueError, "exactly this target's staged binary"):
             rebuild.record(directory, "primary")
         self.assertFalse((directory / rebuild.OBSERVATION).exists())
 

--- a/packaging/test_native_staging_check.py
+++ b/packaging/test_native_staging_check.py
@@ -1,0 +1,77 @@
+"""Explicit fixtures for manual diagnostic isolation and exact byte comparison."""
+
+from contextlib import ExitStack
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import native_staging_check as check
+
+
+class StagingCheckTests(unittest.TestCase):
+    def test_each_previous_path_is_compiled_and_only_equal_bytes_pass(self):
+        for windows in (False, True):
+            for equal in (False, True):
+                with self.subTest(windows=windows, equal=equal), ExitStack() as stack:
+                    root = Path(stack.enter_context(tempfile.TemporaryDirectory()))
+                    binary = "peritusd" if windows else "peritus"
+                    filename = binary + (".exe" if windows else "")
+                    bound = {"candidate": {"fixture": True}, "binary": binary,
+                             "package": "peritus-daemon" if windows else "peritus-cli",
+                             "environment": {"system": "Windows" if windows else "Darwin",
+                                             "machine": "AMD64" if windows else "x86_64"}}
+                    stack.enter_context(patch.object(check, "ROOT", root))
+                    stack.enter_context(patch.object(check.inputs, "binding", return_value=bound))
+                    stack.enter_context(patch.object(check.inputs, "normalize_verified_sources"))
+                    restore = stack.enter_context(patch.object(check.transport, "restore"))
+                    candidate = root / "target/staging-candidate" / filename
+                    candidate.parent.mkdir(parents=True)
+                    candidate.write_bytes(b"staged non-release fixture")
+
+                    def compile_fixture(*_args):
+                        target = root / ("target/release" if windows else "target/native-daemon/release")
+                        target.mkdir(parents=True)
+                        (target / filename).write_bytes(candidate.read_bytes() if equal else b"different fixture")
+                        return {"fixture_observation": True}
+
+                    module = check.windows_release if windows else check.native_build
+                    method = "build" if windows else "compile_phase"
+                    compile_call = stack.enter_context(patch.object(module, method, side_effect=compile_fixture))
+                    if equal:
+                        check.check(binary)
+                    else:
+                        with self.assertRaisesRegex(ValueError, "differs"):
+                            check.check(binary)
+                    compile_call.assert_called_once()
+                    if windows:
+                        restore.assert_not_called()
+                    else:
+                        restore.assert_called_once_with(root / "target/native-daemon-libraries",
+                                                        root / "target/native-daemon",
+                                                        check.inputs.daemon_binding(bound))
+                    report = json.loads((root / "target/native-staging-check.json").read_bytes())
+                    self.assertEqual(report["kind"], "native-staging-diagnostic")
+                    self.assertEqual(report["byte_identical"], equal)
+                    self.assertFalse((root / "target/native-peritusd-build.json").exists())
+                    self.assertFalse((root / "target/native-peritus-build.json").exists())
+                    with self.assertRaisesRegex(ValueError, "fresh"):
+                        check.check(binary)
+                    compile_call.assert_called_once()
+
+    def test_unreviewed_platform_or_binary_cannot_compile(self):
+        for system, machine, binary in (("Linux", "x86_64", "peritusd"),
+                                        ("Darwin", "aarch64", "peritus"),
+                                        ("Windows", "AMD64", "peritus")):
+            bound = {"environment": {"system": system, "machine": machine}}
+            with patch.object(check.inputs, "binding", return_value=bound), \
+                    patch.object(check.windows_release, "build") as windows, \
+                    patch.object(check.native_build, "compile_phase") as mac, self.assertRaises(ValueError):
+                check.check(binary)
+            windows.assert_not_called()
+            mac.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packaging/test_native_transport.py
+++ b/packaging/test_native_transport.py
@@ -19,7 +19,8 @@ class NativeTransportTests(unittest.TestCase):
         (tree / "release/deps").mkdir(parents=True)
         (tree / "release/libperitus_daemon.rlib").write_bytes(b"fixture library")
         (tree / "release/deps/libperitus_daemon-fixture.rlib").write_bytes(b"fixture library")
-        binding = {"candidate": {"fixture": True}, "role": "primary", "environment": {"fixture": True}}
+        binding = {"candidate": {"fixture": True}, "role": "primary", "environment": {"fixture": True},
+                   "binary": "peritusd", "package": "peritus-daemon", "workflow": {"GITHUB_RUN_ATTEMPT": "1"}}
         observation = {"host": "fixture-host", "invocation": "fixture-library",
                        "started_unix_nanos": 1, "finished_unix_nanos": 2,
                        "command": ["cargo", "build", "--release", "--locked", "--package",
@@ -44,7 +45,7 @@ class NativeTransportTests(unittest.TestCase):
             self.assertFalse((destination / "release/peritusd").exists())
 
     def test_changed_candidate_role_or_environment_is_rejected_before_extraction(self):
-        for field in ("candidate", "role", "environment"):
+        for field in ("candidate", "role", "environment", "workflow", "binary", "package"):
             with self.subTest(field=field), tempfile.TemporaryDirectory() as temporary:
                 root = Path(temporary)
                 _, bundle, binding, _ = self.fixture(root)
@@ -96,7 +97,7 @@ class NativeTransportTests(unittest.TestCase):
             self.assertFalse((root / "second-bundle").exists())
 
     def test_missing_libraries_or_prebuilt_product_are_not_a_library_stage(self):
-        for fault in ("library", "binary", "binary-dependency", "binary-fingerprint"):
+        for fault in ("library", "binary", "windows-binary", "binary-dependency", "binary-fingerprint"):
             with self.subTest(fault=fault), tempfile.TemporaryDirectory() as temporary:
                 root = Path(temporary)
                 tree, _, binding, record = self.fixture(root)
@@ -104,6 +105,8 @@ class NativeTransportTests(unittest.TestCase):
                     (tree / "release/libperitus_daemon.rlib").unlink()
                 elif fault == "binary":
                     (tree / "release/peritusd").write_bytes(b"fixture binary")
+                elif fault == "windows-binary":
+                    (tree / "release/peritusd.exe").write_bytes(b"fixture binary")
                 elif fault == "binary-dependency":
                     (tree / "release/deps/peritusd-fixture").write_bytes(b"fixture binary")
                 else:
@@ -115,7 +118,7 @@ class NativeTransportTests(unittest.TestCase):
                 self.assertFalse((root / "second-bundle").exists())
 
     def test_prebuilt_cli_outputs_are_rejected_before_creating_a_library_bundle(self):
-        for name in ("release/peritus", "release/deps/peritus-fixture",
+        for name in ("release/peritus", "release/peritus.exe", "release/PERITUS.EXE", "release/deps/peritus-fixture",
                      "release/.fingerprint/peritus-cli-fixture/bin-peritus"):
             with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
                 root = Path(temporary)
@@ -129,7 +132,9 @@ class NativeTransportTests(unittest.TestCase):
 
     def test_unsafe_tar_members_and_resource_overflow_are_rejected(self):
         for name in ("../escape", "/absolute", "native-daemon/../escape", "native-daemon//bad",
-                     "native-daemon/back\\slash", "another-root/file", "native-daemon/control\n"):
+                     "native-daemon/back\\slash", "native-daemon/C:stream", "native-daemon/CON.txt",
+                     "native-daemon/file.", "native-daemon/file ", "native-daemon/wild*card",
+                     "another-root/file", "native-daemon/control\n"):
             with self.subTest(name=name):
                 member = tarfile.TarInfo(name)
                 with self.assertRaises(ValueError):
@@ -142,6 +147,8 @@ class NativeTransportTests(unittest.TestCase):
         member = tarfile.TarInfo("native-daemon/file")
         with self.assertRaises(ValueError):
             transport.members([member, member])
+        with self.assertRaises(ValueError):
+            transport.members([member, tarfile.TarInfo("native-daemon/FILE")])
         for value in (-1, float("inf")):
             member.mtime = value
             with self.assertRaises(ValueError):

--- a/packaging/test_rebuild.py
+++ b/packaging/test_rebuild.py
@@ -13,7 +13,9 @@ import rebuild
 class NativeRebuildTests(unittest.TestCase):
     def fixture(self, directory, role, payload=b"non-release archive fixture", windows=False):
         directory.mkdir()
-        name = "peritus-windows-x86_64.zip" if windows else "peritus-linux-x86_64.tar.gz"
+        # Non-staged targets exercise the generic archive/checksum comparison here;
+        # native x86-64 Windows evidence is covered with real ZIP fixtures separately.
+        name = "peritus-windows-aarch64.zip" if windows else "peritus-linux-x86_64.tar.gz"
         (directory / name).write_bytes(payload)
         (directory / (name + ".sha256")).write_bytes(
             hashlib.sha256(payload).hexdigest().encode() + b"\n")

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -13,58 +13,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-const HELP: &str = "Peritus workspace policy tool
-
-Usage: cargo xtask <command>
-
-Commands:
-  all                    Run all locally executable repository policy checks
-  architecture-check     Validate packages, layers, ownership, and source layout
-  docs-check             Validate maintained Markdown structure and local links
-  format-check           Check every workspace package without one oversized command line
-  ordinary-api-check     Validate formal APIs callable from ordinary safe Rust
-  source-layout-check    Validate module names, crate roots, and source budgets
-  reproducibility-check  Validate toolchain pins, lock policy, and immutable CI inputs
-  toolchain-check        Probe installed Rust, Verus, vstd metadata, and bundled Z3
-  verify-trust           Reject trusted Verus constructs outside approved roots
-  ci-shard OPERATION SHARD Run one reviewed package shard for hosted Rust or Verus CI
-  product-package        Build a host-native checked Peritus package in dist/
-  product-install        Build and install Peritus for the current user
-  product-package-smoke  Qualify native install, repeat launch, upgrade, and uninstall
-  product-native-qualification Run and retain all 18 native H2 package scenarios
-  product-native-qualification-shard INDEX Run one of 18 single-scenario H2 shards
-  product-native-qualification-prepare Assemble previously built native H2 artifacts
-  product-native-qualification-restore Restore this platform's same-run native H2 archive
-  product-native-qualification-prepared-shard INDEX Qualify same-run artifacts without Cargo
-  release-bootstrap-smoke Qualify the public download, checksum, and install entry point
-  release-bootstrap-prepared-smoke Qualify the public installer using same-run native artifacts
-  release-bootstrap-staged-smoke Qualify the public installer using the exact staged archive
-  release-qualification-prepare Restore the staged release archive and retain H2 inputs
-  release-rebuild-record Retain actual source, environment, and native assembly observations
-  release-rebuild-compare Require a compatible byte-identical independent native rebuild
-  release-daemon-library Compile and retain a same-run native daemon library tree
-  release-daemon-binary Compile the final daemon from its verified same-role library tree
-  release-cli-binary     Compile the CLI from its verified same-role daemon libraries
-  release-windows-binary Compile a selected native Windows x86-64 binary with pinned C tooling
-  release-windows-sqlite-check Compare two fresh native Windows bundled SQLite compilations
-  release-create         Validate a tag and create its retained draft GitHub release
-  release-package-stage Build, archive, checksum, and record this host's native package
-  release-package-assemble Assemble a native package from separately built release binaries
-  release-stage          Complete and validate the release draft without publishing it
-  distro-image           Build a pinned Debian or Fedora package-builder Docker image
-  distro-image-save      Retain the exact builder image for same-run package jobs
-  distro-image-restore   Restore the same-run builder image without rebuilding it
-  distro-build           Build real source and binary distribution packages offline
-  distro-compile         Retain a candidate-bound native distribution compilation
-  distro-compile-checks  Retain native RPM check compilation for final recipe execution
-  distro-package-compiled  Run full recipes and tests on the same-run compiled tree
-  distro-sign            Sign distribution packages using the local OpenPGP agent
-  distro-sign-ci         Sign with explicitly provisioned protected-environment CI secrets
-  distro-verify          Verify package signatures and disposable install/remove lifecycle
-  distro-upload          Upload a verified package set to the exact existing release draft
-  distro-test            Run distribution package tooling regression tests
-  help                   Print this help
-";
+use help::HELP;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Command {
@@ -392,6 +341,7 @@ fn write_output(output: &mut dyn Write, message: &str) -> Result<(), XtaskError>
         .map_err(|error| XtaskError::io("write", Path::new("<stdout>"), error))
 }
 
+mod help;
 mod product;
 mod shard_args;
 use product::execute_product;

--- a/xtask/src/cli/help.rs
+++ b/xtask/src/cli/help.rs
@@ -1,0 +1,56 @@
+//! Human-readable command inventory, separate from argument parsing and execution.
+
+pub(super) const HELP: &str = "Peritus workspace policy tool
+
+Usage: cargo xtask <command>
+
+Commands:
+  all                    Run all locally executable repository policy checks
+  architecture-check     Validate packages, layers, ownership, and source layout
+  docs-check             Validate maintained Markdown structure and local links
+  format-check           Check every workspace package without one oversized command line
+  ordinary-api-check     Validate formal APIs callable from ordinary safe Rust
+  source-layout-check    Validate module names, crate roots, and source budgets
+  reproducibility-check  Validate toolchain pins, lock policy, and immutable CI inputs
+  toolchain-check        Probe installed Rust, Verus, vstd metadata, and bundled Z3
+  verify-trust           Reject trusted Verus constructs outside approved roots
+  ci-shard OPERATION SHARD Run one reviewed package shard for hosted Rust or Verus CI
+  product-package        Build a host-native checked Peritus package in dist/
+  product-install        Build and install Peritus for the current user
+  product-package-smoke  Qualify native install, repeat launch, upgrade, and uninstall
+  product-native-qualification Run and retain all 18 native H2 package scenarios
+  product-native-qualification-shard INDEX Run one of 18 single-scenario H2 shards
+  product-native-qualification-prepare Assemble previously built native H2 artifacts
+  product-native-qualification-restore Restore this platform's same-run native H2 archive
+  product-native-qualification-prepared-shard INDEX Qualify same-run artifacts without Cargo
+  release-bootstrap-smoke Qualify the public download, checksum, and install entry point
+  release-bootstrap-prepared-smoke Qualify the public installer using same-run native artifacts
+  release-bootstrap-staged-smoke Qualify the public installer using the exact staged archive
+  release-qualification-prepare Restore the staged release archive and retain H2 inputs
+  release-rebuild-record Retain actual source, environment, and native assembly observations
+  release-rebuild-compare Require a compatible byte-identical independent native rebuild
+  release-daemon-library Compile and retain a same-run native daemon library tree
+  release-daemon-binary Compile the final daemon from its verified same-role library tree
+  release-cli-library    Compile CLI libraries from verified same-role daemon libraries
+  release-staging-check  Compare staged products with the previous native build path
+  release-cli-binary     Compile the CLI from its verified same-role CLI libraries
+  release-windows-binary Compile a selected native Windows x86-64 binary with pinned C tooling
+  release-windows-sqlite-check Compare two fresh native Windows bundled SQLite compilations
+  release-create         Validate a tag and create its retained draft GitHub release
+  release-package-stage Build, archive, checksum, and record this host's native package
+  release-package-assemble Assemble a native package from separately built release binaries
+  release-stage          Complete and validate the release draft without publishing it
+  distro-image           Build a pinned Debian or Fedora package-builder Docker image
+  distro-image-save      Retain the exact builder image for same-run package jobs
+  distro-image-restore   Restore the same-run builder image without rebuilding it
+  distro-build           Build real source and binary distribution packages offline
+  distro-compile         Retain a candidate-bound native distribution compilation
+  distro-compile-checks  Retain native RPM check compilation for final recipe execution
+  distro-package-compiled  Run full recipes and tests on the same-run compiled tree
+  distro-sign            Sign distribution packages using the local OpenPGP agent
+  distro-sign-ci         Sign with explicitly provisioned protected-environment CI secrets
+  distro-verify          Verify package signatures and disposable install/remove lifecycle
+  distro-upload          Upload a verified package set to the exact existing release draft
+  distro-test            Run distribution package tooling regression tests
+  help                   Print this help
+";

--- a/xtask/src/cli/tests.rs
+++ b/xtask/src/cli/tests.rs
@@ -33,6 +33,8 @@ fn native_rebuild_commands_select_exact_operations() {
         ("release-daemon-library", Operation::Library),
         ("release-daemon-binary", Operation::DaemonBinary),
         ("release-cli-binary", Operation::CliBinary),
+        ("release-cli-library", Operation::CliLibrary),
+        ("release-staging-check", Operation::StagingCheck),
         ("release-windows-binary", Operation::WindowsBinary),
         ("release-windows-sqlite-check", Operation::WindowsSqliteCheck),
     ] {

--- a/xtask/src/release/publication/tests/native_compilation.rs
+++ b/xtask/src/release/publication/tests/native_compilation.rs
@@ -2,9 +2,36 @@
 
 use super::*;
 
-const DAEMON: &str =
-    "${{ matrix.target.os == 'macos-15-intel' && matrix.target.binary == 'peritusd' }}";
-const CONSUMERS: &str = "${{ matrix.target.os == 'macos-15-intel' && (matrix.target.binary == 'peritusd' || matrix.target.binary == 'peritus') }}";
+const DAEMON: &str = "${{ (matrix.target.os == 'macos-15-intel' || matrix.target.os == 'windows-2025') && matrix.target.binary == 'peritusd' }}";
+const CONSUMERS: &str = "${{ (matrix.target.os == 'macos-15-intel' && (matrix.target.binary == 'peritusd' || matrix.target.binary == 'peritus')) || (matrix.target.os == 'windows-2025' && matrix.target.binary == 'peritusd') }}";
+
+#[test]
+fn previous_staging_comparison_is_manual_only_and_cannot_supply_release_products() {
+    let document = workflow(".github/workflows/release.yml");
+    let job = &document["jobs"]["check-native-staging"];
+    assert_eq!(job["if"].as_str(), Some("${{ github.event_name == 'workflow_dispatch' }}"));
+    assert_eq!(job["needs"].as_str(), Some("build-binary"));
+    assert_eq!(job["timeout-minutes"].as_i64(), Some(10));
+    assert_eq!(job["env"]["PERITUS_RELEASE_BUILD_ROLE"].as_str(), Some("primary"));
+    let rows = job["strategy"]["matrix"]["target"].as_vec().expect("diagnostic targets");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["os"].as_str(), Some("macos-15-intel"));
+    assert_eq!(rows[0]["binary"].as_str(), Some("peritus"));
+    assert_eq!(rows[1]["os"].as_str(), Some("windows-2025"));
+    assert_eq!(rows[1]["binary"].as_str(), Some("peritusd"));
+    let steps = job["steps"].as_vec().expect("diagnostic steps");
+    let uploads = steps
+        .iter()
+        .filter(|step| step["uses"].as_str().is_some_and(|name| name.contains("upload-artifact")))
+        .collect::<Vec<_>>();
+    assert_eq!(uploads.len(), 1);
+    assert_eq!(uploads[0]["with"]["path"].as_str(), Some("target/native-staging-check.json"));
+    assert_eq!(
+        uploads[0]["with"]["name"].as_str(),
+        Some("release-staging-check-${{ matrix.target.os }}")
+    );
+    assert_eq!(document["jobs"]["assemble"]["needs"].as_str(), Some("build-binary"));
+}
 
 #[test]
 fn intel_cli_has_a_reviewed_same_role_library_consumer() {
@@ -24,19 +51,69 @@ fn intel_cli_has_a_reviewed_same_role_library_consumer() {
 }
 
 #[test]
-fn native_library_producers_are_independent_fresh_and_scoped_to_intel_macos() {
+fn intel_cli_library_stage_retains_the_original_role_bound_daemon_chain_without_a_binary() {
+    let document = workflow(".github/workflows/release.yml");
+    let stage = &document["jobs"]["build-cli-library"];
+    assert_eq!(stage["needs"].as_str(), Some("build-daemon-library"));
+    assert_eq!(stage["runs-on"].as_str(), Some("macos-15-intel"));
+    assert_eq!(stage["timeout-minutes"].as_i64(), Some(10));
+    assert_eq!(stage["strategy"]["fail-fast"].as_bool(), Some(false));
+    assert_eq!(stage["strategy"]["matrix"].as_hash().expect("CLI matrix").len(), 1);
+    assert_eq!(
+        stage["strategy"]["matrix"]["build"].as_vec().expect("CLI roles"),
+        &[Yaml::String("primary".into()), Yaml::String("independent".into())]
+    );
+    assert_eq!(stage["env"]["CARGO_BUILD_JOBS"].as_str(), Some("4"));
+    assert_eq!(stage["env"]["PERITUS_RELEASE_BUILD_ROLE"].as_str(), Some("${{ matrix.build }}"));
+    let steps = stage["steps"].as_vec().expect("CLI steps");
+    assert_eq!(
+        steps.iter().filter_map(|step| step["run"].as_str()).collect::<Vec<_>>(),
+        ["cargo run --locked --package xtask -- release-cli-library"]
+    );
+    assert!(
+        !steps.iter().any(|step| step["uses"].as_str().is_some_and(|name| name.contains("cache")))
+    );
+    let downloads = steps
+        .iter()
+        .filter(|step| step["uses"].as_str().is_some_and(|name| name.contains("download-artifact")))
+        .collect::<Vec<_>>();
+    assert_eq!(downloads.len(), 1);
+    assert_eq!(downloads[0]["with"].as_hash().expect("same-run options").len(), 2);
+    assert_eq!(
+        downloads[0]["with"]["name"].as_str(),
+        Some("release-libraries-${{ matrix.build }}-macos-15-intel-peritusd")
+    );
+    assert_eq!(downloads[0]["with"]["path"].as_str(), Some("target/native-daemon-libraries"));
+    let upload = steps.last().expect("CLI library upload");
+    assert_eq!(
+        upload["with"]["name"].as_str(),
+        Some("release-libraries-${{ matrix.build }}-macos-15-intel-peritus")
+    );
+    assert_eq!(upload["with"]["path"].as_str(), Some("target/native-cli-libraries"));
+    assert_eq!(upload["with"]["if-no-files-found"].as_str(), Some("error"));
+}
+
+#[test]
+fn native_library_producers_are_independent_fresh_and_scoped_to_oversized_native_targets() {
     let document = workflow(".github/workflows/release.yml");
     let producer = &document["jobs"]["build-daemon-library"];
-    assert_eq!(producer["runs-on"].as_str(), Some("macos-15-intel"));
+    assert_eq!(producer["runs-on"].as_str(), Some("${{ matrix.os }}"));
     assert_eq!(producer["timeout-minutes"].as_i64(), Some(10));
     assert_eq!(producer["strategy"]["fail-fast"].as_bool(), Some(false));
     let matrix = &producer["strategy"]["matrix"];
-    assert_eq!(matrix.as_hash().expect("library matrix").len(), 1);
+    assert_eq!(matrix.as_hash().expect("library matrix").len(), 2);
+    assert_eq!(
+        matrix["os"].as_vec().expect("native hosts"),
+        &[Yaml::String("macos-15-intel".into()), Yaml::String("windows-2025".into())]
+    );
     assert_eq!(
         matrix["build"].as_vec().expect("roles"),
         &[Yaml::String("primary".into()), Yaml::String("independent".into())]
     );
-    assert_eq!(producer["env"]["CARGO_BUILD_JOBS"].as_str(), Some("4"));
+    assert_eq!(
+        producer["env"]["CARGO_BUILD_JOBS"].as_str(),
+        Some("${{ matrix.os == 'macos-15-intel' && '4' || '2' }}")
+    );
     assert_eq!(producer["env"]["PERITUS_RELEASE_BUILD_ROLE"].as_str(), Some("${{ matrix.build }}"));
     let steps = producer["steps"].as_vec().expect("library steps");
     assert!(!steps.iter().any(|step| {
@@ -51,11 +128,14 @@ fn native_library_producers_are_independent_fresh_and_scoped_to_intel_macos() {
     let upload = steps.last().expect("library upload");
     assert_eq!(
         upload["with"]["name"].as_str(),
-        Some("release-libraries-${{ matrix.build }}-macos-15-intel-peritusd")
+        Some("release-libraries-${{ matrix.build }}-${{ matrix.os }}-peritusd")
     );
     assert_eq!(upload["with"]["path"].as_str(), Some("target/native-daemon-libraries"));
     assert_eq!(upload["with"]["if-no-files-found"].as_str(), Some("error"));
-    assert_eq!(document["jobs"]["build-binary"]["needs"].as_str(), Some("build-daemon-library"));
+    assert_eq!(
+        document["jobs"]["build-binary"]["needs"].as_vec().expect("producer dependencies"),
+        &[Yaml::String("build-daemon-library".into()), Yaml::String("build-cli-library".into())]
+    );
 }
 
 #[test]
@@ -70,7 +150,10 @@ fn every_binary_keeps_its_native_command_or_uses_only_its_verified_daemon_librar
             "${{ runner.os != 'Windows' && (matrix.target.os != 'macos-15-intel' || (matrix.target.binary != 'peritusd' && matrix.target.binary != 'peritus')) }}"
         )
     );
-    assert_eq!(commands[1]["if"].as_str(), Some("${{ matrix.target.os == 'windows-2025' }}"));
+    assert_eq!(
+        commands[1]["if"].as_str(),
+        Some("${{ matrix.target.os == 'windows-2025' && matrix.target.binary != 'peritusd' }}")
+    );
     assert_eq!(commands[2]["if"].as_str(), Some("${{ matrix.target.os == 'windows-11-arm' }}"));
     assert_eq!(commands[3]["if"].as_str(), Some(DAEMON));
     assert_eq!(
@@ -97,7 +180,10 @@ fn every_binary_keeps_its_native_command_or_uses_only_its_verified_daemon_librar
         .iter()
         .find(|step| step["with"]["path"].as_str() == Some("target/native-compile-record"))
         .expect("assembly evidence");
-    assert_eq!(download["if"].as_str(), Some("${{ matrix.os == 'macos-15-intel' }}"));
+    assert_eq!(
+        download["if"].as_str(),
+        Some("${{ matrix.os == 'macos-15-intel' || matrix.os == 'windows-2025' }}")
+    );
     assert_eq!(download["with"].as_hash().expect("same-run evidence").len(), 3);
     assert_eq!(
         download["with"]["pattern"].as_str(),

--- a/xtask/src/release/publication/tests/native_rebuild.rs
+++ b/xtask/src/release/publication/tests/native_rebuild.rs
@@ -64,15 +64,22 @@ fn independent_build_is_a_real_cartesian_axis_for_every_native_binary_and_archiv
     assert_eq!(
         download["if"].as_str(),
         Some(
-            "${{ matrix.target.os == 'macos-15-intel' && (matrix.target.binary == 'peritusd' || matrix.target.binary == 'peritus') }}"
+            "${{ (matrix.target.os == 'macos-15-intel' && (matrix.target.binary == 'peritusd' || matrix.target.binary == 'peritus')) || (matrix.target.os == 'windows-2025' && matrix.target.binary == 'peritusd') }}"
         )
     );
     assert_eq!(download["with"].as_hash().expect("same-run library inputs").len(), 2);
     assert_eq!(
         download["with"]["name"].as_str(),
-        Some("release-libraries-${{ matrix.build }}-${{ matrix.target.os }}-peritusd")
+        Some(
+            "release-libraries-${{ matrix.build }}-${{ matrix.target.os }}-${{ matrix.target.binary }}"
+        )
     );
-    assert_eq!(download["with"]["path"].as_str(), Some("target/native-daemon-libraries"));
+    assert_eq!(
+        download["with"]["path"].as_str(),
+        Some(
+            "target/native-${{ matrix.target.binary == 'peritus' && 'cli' || 'daemon' }}-libraries"
+        )
+    );
     let upload = build.last().expect("binary upload");
     assert_eq!(
         upload["with"]["name"].as_str(),

--- a/xtask/src/release/publication/tests/native_windows.rs
+++ b/xtask/src/release/publication/tests/native_windows.rs
@@ -9,7 +9,7 @@ fn windows_release_binaries_use_reviewed_native_compilation_and_deterministic_li
     let steps = build["steps"].as_vec().expect("binary steps");
     for (condition, command) in [
         (
-            "${{ matrix.target.os == 'windows-2025' }}",
+            "${{ matrix.target.os == 'windows-2025' && matrix.target.binary != 'peritusd' }}",
             "cargo run --locked --package xtask -- release-windows-binary",
         ),
         (

--- a/xtask/src/release/rebuild.rs
+++ b/xtask/src/release/rebuild.rs
@@ -9,10 +9,12 @@ pub(crate) enum Operation {
     Record,
     Compare,
     Library,
+    CliLibrary,
     DaemonBinary,
     CliBinary,
     WindowsBinary,
     WindowsSqliteCheck,
+    StagingCheck,
 }
 
 impl Operation {
@@ -21,10 +23,12 @@ impl Operation {
             "release-rebuild-record" => Some(Self::Record),
             "release-rebuild-compare" => Some(Self::Compare),
             "release-daemon-library" => Some(Self::Library),
+            "release-cli-library" => Some(Self::CliLibrary),
             "release-daemon-binary" => Some(Self::DaemonBinary),
             "release-cli-binary" => Some(Self::CliBinary),
             "release-windows-binary" => Some(Self::WindowsBinary),
             "release-windows-sqlite-check" => Some(Self::WindowsSqliteCheck),
+            "release-staging-check" => Some(Self::StagingCheck),
             _ => None,
         }
     }
@@ -41,9 +45,9 @@ pub(crate) fn run(root: &Path, operation: Operation) -> Result<(), XtaskError> {
             XtaskError::invocation("PERITUS_RELEASE_BUILD_ROLE must be primary or independent")
         })?)
     };
-    let binary = if operation == Operation::WindowsBinary {
+    let binary = if matches!(operation, Operation::WindowsBinary | Operation::StagingCheck) {
         Some(env::var("PERITUS_RELEASE_BINARY").map_err(|_| {
-            XtaskError::invocation("PERITUS_RELEASE_BINARY must select a reviewed Windows binary")
+            XtaskError::invocation("PERITUS_RELEASE_BINARY must select a reviewed native binary")
         })?)
     } else {
         None
@@ -61,15 +65,18 @@ fn command(
     binary: Option<&str>,
 ) -> Result<Command, XtaskError> {
     let mut command = Command::new(if cfg!(windows) { "python" } else { "python3" });
-    let script =
-        if matches!(operation, Operation::Library | Operation::DaemonBinary | Operation::CliBinary)
-        {
-            "packaging/native_build.py"
-        } else if matches!(operation, Operation::WindowsBinary | Operation::WindowsSqliteCheck) {
-            "packaging/windows_release.py"
-        } else {
-            "packaging/rebuild.py"
-        };
+    let script = if matches!(
+        operation,
+        Operation::Library | Operation::CliLibrary | Operation::DaemonBinary | Operation::CliBinary
+    ) {
+        "packaging/native_build.py"
+    } else if operation == Operation::StagingCheck {
+        "packaging/native_staging_check.py"
+    } else if matches!(operation, Operation::WindowsBinary | Operation::WindowsSqliteCheck) {
+        "packaging/windows_release.py"
+    } else {
+        "packaging/rebuild.py"
+    };
     command.current_dir(root).arg(root.join(script));
     match operation {
         Operation::Record => {
@@ -86,6 +93,10 @@ fn command(
         Operation::Library => {
             command.env("PERITUS_RELEASE_BUILD_ROLE", require_role(role)?);
             command.arg("library");
+        }
+        Operation::CliLibrary => {
+            command.env("PERITUS_RELEASE_BUILD_ROLE", require_role(role)?);
+            command.args(["library", "peritus"]);
         }
         Operation::DaemonBinary | Operation::CliBinary => {
             let binary = if operation == Operation::DaemonBinary { "peritusd" } else { "peritus" };
@@ -108,6 +119,15 @@ fn command(
         Operation::WindowsSqliteCheck => {
             command.arg("check-sqlite");
         }
+        Operation::StagingCheck => {
+            let binary = binary
+                .filter(|value| matches!(*value, "peritus" | "peritusd"))
+                .ok_or_else(|| {
+                    XtaskError::invocation("staging comparison requires a reviewed native consumer")
+                })?;
+            command.env("PERITUS_RELEASE_BUILD_ROLE", require_role(role)?);
+            command.arg(binary);
+        }
     }
     Ok(command)
 }
@@ -128,6 +148,8 @@ mod tests {
             for operation in [
                 Operation::Record,
                 Operation::Library,
+                Operation::CliLibrary,
+                Operation::StagingCheck,
                 Operation::DaemonBinary,
                 Operation::CliBinary,
             ] {
@@ -154,6 +176,7 @@ mod tests {
     fn native_phases_select_only_the_reviewed_compiler_and_binary() {
         for (operation, arguments) in [
             (Operation::Library, vec!["library"]),
+            (Operation::CliLibrary, vec!["library", "peritus"]),
             (Operation::DaemonBinary, vec!["binary", "peritusd"]),
             (Operation::CliBinary, vec!["binary", "peritus"]),
         ] {
@@ -187,5 +210,22 @@ mod tests {
         let command =
             command(root, Operation::WindowsSqliteCheck, None, None).expect("SQLite check");
         assert_eq!(command.get_args().skip(1).collect::<Vec<_>>(), ["check-sqlite"]);
+    }
+
+    #[test]
+    fn staging_check_selects_only_the_diagnostic_script_and_closed_consumer_names() {
+        let root = Path::new(".");
+        for binary in [None, Some(""), Some("peritus; exit 0"), Some("peritus-tui")] {
+            assert!(command(root, Operation::StagingCheck, Some("primary"), binary).is_err());
+        }
+        for binary in ["peritus", "peritusd"] {
+            let command = command(root, Operation::StagingCheck, Some("primary"), Some(binary))
+                .expect("diagnostic comparison");
+            assert_eq!(
+                command.get_args().next(),
+                Some(root.join("packaging/native_staging_check.py").as_os_str())
+            );
+            assert_eq!(command.get_args().skip(1).collect::<Vec<_>>(), [binary]);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Split the native x86-64 Windows daemon library compilation from its existing deterministic final link, and insert an Intel Mac CLI-library stage using its own dependency features.
- Retain exact candidate, role, environment, workflow-attempt and ordered parent-library provenance; validate shipped tar/ZIP bytes and reject prebuilt products and unsafe Windows transport names.
- Add manual-only comparisons with the previous compilation paths. Diagnostic binaries cannot enter release assembly.
- Keep all release profiles, supported platforms, signing controls, independent rebuild gates and ten-minute job ceilings unchanged. Move CLI help text into its own module to preserve the existing source budget.

## Verification

- 332 xtask unit tests and 7 integration tests passed.
- 52 native packaging tests and 44 distribution-tooling tests passed.
- Strict clippy, format check, actionlint and xtask all passed.
- Exact-head hosted native validation and previous-path byte comparison are pending and required before retagging.

Crosslink #57. The release remains a draft; the owner approved this staging repair and replacement of the still-draft tag after validation.