### PR TITLE
fix(release): allow twenty minutes for compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
         build: [primary, independent]
         os: [macos-15-intel, windows-2025]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       CARGO_BUILD_JOBS: ${{ matrix.os == 'macos-15-intel' && '4' || '2' }}
       PERITUS_RELEASE_BUILD_ROLE: ${{ matrix.build }}
@@ -233,7 +233,7 @@ jobs:
       matrix:
         build: [primary, independent]
     runs-on: macos-15-intel
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       CARGO_BUILD_JOBS: "4"
       PERITUS_RELEASE_BUILD_ROLE: ${{ matrix.build }}
@@ -293,7 +293,7 @@ jobs:
           - { os: windows-2025, package: peritus-sandbox-windows, binary: peritus-windows-sandbox-helper, artifact: peritus-windows-sandbox-helper.exe }
           - { os: windows-11-arm, package: peritus-sandbox-windows, binary: peritus-windows-sandbox-helper, artifact: peritus-windows-sandbox-helper.exe }
     runs-on: ${{ matrix.target.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       # The public Intel macOS runner has four CPUs; keep other targets at two.
       CARGO_BUILD_JOBS: ${{ matrix.target.os == 'macos-15-intel' && '4' || '2' }}
@@ -364,7 +364,7 @@ jobs:
           - { os: macos-15-intel, binary: peritus }
           - { os: windows-2025, binary: peritusd }
     runs-on: ${{ matrix.target.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       CARGO_BUILD_JOBS: ${{ matrix.target.os == 'macos-15-intel' && '4' || '2' }}
       PERITUS_RELEASE_BUILD_ROLE: primary
@@ -582,7 +582,7 @@ jobs:
           - { os: ubuntu-24.04, arch: x86_64, format: rpm }
           - { os: ubuntu-24.04-arm, arch: aarch64, format: rpm }
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       PERITUS_PACKAGE_FORMAT: ${{ matrix.format }}
       PERITUS_PACKAGE_MAINTAINER: ${{ vars.PERITUS_PACKAGE_MAINTAINER }}
@@ -625,7 +625,7 @@ jobs:
           - { os: ubuntu-24.04, arch: x86_64, format: rpm }
           - { os: ubuntu-24.04-arm, arch: aarch64, format: rpm }
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       PERITUS_PACKAGE_FORMAT: ${{ matrix.format }}
       PERITUS_PACKAGE_MAINTAINER: ${{ vars.PERITUS_PACKAGE_MAINTAINER }}

--- a/packaging/native-build.md
+++ b/packaging/native-build.md
@@ -13,9 +13,17 @@ four build jobs. The native x86-64 Windows daemon also exceeded that ceiling.
 The daemon library producer and each final binary now have separate bounded
 native phases on these hosts. Intel macOS adds a dedicated CLI-library phase
 between its original daemon libraries and the final CLI binary. The other native binary commands, supported platforms, release profile, locked
-dependencies, and ten-minute limits are unchanged. The binary matrix waits for
+dependencies, and compilation commands are unchanged. The binary matrix waits for
 all independent library producers before starting; no role borrows another
 role's compilation.
+
+Release compilation jobs now allow twenty minutes, including setup, compilation,
+library transport, and artifact upload. The previous ten-minute limit could expire
+after Cargo completed but before its outputs were retained. The exception is limited
+to the native library and binary producers, the manual previous-path compilation
+comparison, and distribution product/check compilation. Assembly, qualification,
+signing, and other hosted jobs retain their ten-minute ceilings. No timeout change
+relaxes candidate binding, independent rebuilds, or required tests.
 
 The existing library target is selected with `cargo build --release --locked
 --package peritus-daemon --lib`. The final phase still runs the corresponding

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -39,7 +39,15 @@ The public installer lifecycle and all 18 H2 scenarios consume that platform's s
 artifact without rebuilding the application. The small xtask entry point still uses the
 reviewed locked Cargo command; its prepared execution path never invokes Cargo. Missing artifacts
 fail rather than triggering a rebuild. The local build-and-qualify commands remain available, and
-every hosted job retains its ten-minute limit.
+these native product CI jobs retain their ten-minute limit.
+
+Hosted jobs default to a ten-minute ceiling. Only six named compilation jobs in
+`.github/workflows/release.yml` have a twenty-minute allowance: `build-daemon-library`,
+`build-cli-library`, `build-binary`, `check-native-staging`, `distro-compile`, and
+`distro-compile-checks`. This includes setup and artifact retention, not just Cargo
+execution. Policy rejects larger limits, other job names, and the same names in
+other workflows. Qualification, assembly, signing, and publication checks keep
+their existing ten-minute limits and requirements.
 
 Native release and bootstrap archives require Python 3.12+ on the build host
 (`python3` on Unix, `python` on Windows), not on the installed product host.

--- a/xtask/src/release/publication/tests/distribution.rs
+++ b/xtask/src/release/publication/tests/distribution.rs
@@ -5,7 +5,8 @@ fn distribution_matrix_builds_and_signs_each_format_on_each_native_architecture(
     let document = workflow(".github/workflows/release.yml");
     for job in ["distro-image", "distro-compile", "distro-build", "distro-sign"] {
         let definition = &document["jobs"][job];
-        assert_eq!(definition["timeout-minutes"].as_i64(), Some(10));
+        let timeout = if job == "distro-compile" { 20 } else { 10 };
+        assert_eq!(definition["timeout-minutes"].as_i64(), Some(timeout));
         assert_eq!(definition["strategy"]["fail-fast"].as_bool(), Some(false));
         let rows = definition["strategy"]["matrix"]["include"].as_vec().expect("distro matrix");
         assert_eq!(rows.len(), 4);
@@ -55,7 +56,7 @@ fn distribution_matrix_builds_and_signs_each_format_on_each_native_architecture(
 }
 
 #[test]
-fn release_build_capacity_is_scoped_without_loosening_profiles_or_deadlines() {
+fn release_build_capacity_and_longer_deadlines_are_scoped_to_compilation() {
     let document = workflow(".github/workflows/release.yml");
     assert_eq!(document["env"]["CARGO_BUILD_JOBS"].as_str(), Some("2"));
     let jobs = &document["jobs"];
@@ -70,7 +71,22 @@ fn release_build_capacity_is_scoped_without_loosening_profiles_or_deadlines() {
         Some("4")
     );
     for (name, job) in jobs.as_hash().expect("release jobs") {
-        assert_eq!(job["timeout-minutes"].as_i64(), Some(10));
+        let timeout = if matches!(
+            name.as_str(),
+            Some(
+                "build-daemon-library"
+                    | "build-cli-library"
+                    | "build-binary"
+                    | "check-native-staging"
+                    | "distro-compile"
+                    | "distro-compile-checks"
+            )
+        ) {
+            20
+        } else {
+            10
+        };
+        assert_eq!(job["timeout-minutes"].as_i64(), Some(timeout), "{name:?}");
         if !matches!(
             name.as_str(),
             Some("distro-build" | "distro-compile" | "distro-compile-checks")

--- a/xtask/src/release/publication/tests/native_compilation.rs
+++ b/xtask/src/release/publication/tests/native_compilation.rs
@@ -11,7 +11,7 @@ fn previous_staging_comparison_is_manual_only_and_cannot_supply_release_products
     let job = &document["jobs"]["check-native-staging"];
     assert_eq!(job["if"].as_str(), Some("${{ github.event_name == 'workflow_dispatch' }}"));
     assert_eq!(job["needs"].as_str(), Some("build-binary"));
-    assert_eq!(job["timeout-minutes"].as_i64(), Some(10));
+    assert_eq!(job["timeout-minutes"].as_i64(), Some(20));
     assert_eq!(job["env"]["PERITUS_RELEASE_BUILD_ROLE"].as_str(), Some("primary"));
     let rows = job["strategy"]["matrix"]["target"].as_vec().expect("diagnostic targets");
     assert_eq!(rows.len(), 2);
@@ -56,7 +56,7 @@ fn intel_cli_library_stage_retains_the_original_role_bound_daemon_chain_without_
     let stage = &document["jobs"]["build-cli-library"];
     assert_eq!(stage["needs"].as_str(), Some("build-daemon-library"));
     assert_eq!(stage["runs-on"].as_str(), Some("macos-15-intel"));
-    assert_eq!(stage["timeout-minutes"].as_i64(), Some(10));
+    assert_eq!(stage["timeout-minutes"].as_i64(), Some(20));
     assert_eq!(stage["strategy"]["fail-fast"].as_bool(), Some(false));
     assert_eq!(stage["strategy"]["matrix"].as_hash().expect("CLI matrix").len(), 1);
     assert_eq!(
@@ -98,7 +98,7 @@ fn native_library_producers_are_independent_fresh_and_scoped_to_oversized_native
     let document = workflow(".github/workflows/release.yml");
     let producer = &document["jobs"]["build-daemon-library"];
     assert_eq!(producer["runs-on"].as_str(), Some("${{ matrix.os }}"));
-    assert_eq!(producer["timeout-minutes"].as_i64(), Some(10));
+    assert_eq!(producer["timeout-minutes"].as_i64(), Some(20));
     assert_eq!(producer["strategy"]["fail-fast"].as_bool(), Some(false));
     let matrix = &producer["strategy"]["matrix"];
     assert_eq!(matrix.as_hash().expect("library matrix").len(), 2);

--- a/xtask/src/release/publication/tests/native_rebuild.rs
+++ b/xtask/src/release/publication/tests/native_rebuild.rs
@@ -42,7 +42,8 @@ fn independent_build_is_a_real_cartesian_axis_for_every_native_binary_and_archiv
             matrix["build"].as_vec().expect("independent build axis"),
             &[Yaml::String("primary".into()), Yaml::String("independent".into()),]
         );
-        assert_eq!(document["jobs"][job]["timeout-minutes"].as_i64(), Some(10));
+        let timeout = if job == "build-binary" { 20 } else { 10 };
+        assert_eq!(document["jobs"][job]["timeout-minutes"].as_i64(), Some(timeout));
         let steps = document["jobs"][job]["steps"].as_vec().expect("steps");
         assert!(
             !steps

--- a/xtask/src/reproducibility.rs
+++ b/xtask/src/reproducibility.rs
@@ -54,6 +54,7 @@ mod workflow_pins;
 mod workflow_policy;
 mod workflow_run;
 mod workflow_rust_matrix;
+mod workflow_timeout;
 
 pub(crate) use evidence_command::is_exact_package_gate as is_exact_evidence_command;
 

--- a/xtask/src/reproducibility/reproducibility_workflow_tests.rs
+++ b/xtask/src/reproducibility/reproducibility_workflow_tests.rs
@@ -186,7 +186,7 @@ jobs:
 }
 
 #[test]
-fn every_hosted_job_requires_a_ten_minute_or_shorter_timeout() {
+fn ordinary_hosted_jobs_require_a_ten_minute_or_shorter_timeout() {
     let yaml = r"
 name: slow runner
 jobs:

--- a/xtask/src/reproducibility/workflow_policy.rs
+++ b/xtask/src/reproducibility/workflow_policy.rs
@@ -5,6 +5,7 @@ use super::workflow_governance;
 use super::workflow_local::{LocalUseKind, validate_local_reference};
 use super::workflow_pins::{validate_pin_occurrences, validate_required_ci_pins};
 use super::workflow_run;
+use super::workflow_timeout;
 use crate::error::{Diagnostic, XtaskError};
 use crate::model::ToolchainPolicy;
 use std::fs;
@@ -169,7 +170,7 @@ fn validate_job(
     match job {
         Yaml::Hash(mapping) => {
             workflow_run::reject_defaults(mapping, path, location, diagnostics);
-            validate_job_timeout(mapping, path, location, diagnostics);
+            workflow_timeout::validate(mapping, path, location, diagnostics);
             let mut count = mapping_value(mapping, "uses").map_or(0, |uses| {
                 validate_uses(
                     root,
@@ -217,22 +218,6 @@ fn validate_job(
             })
             .sum(),
         _ => 0,
-    }
-}
-
-fn validate_job_timeout(
-    mapping: &Hash,
-    path: &Path,
-    location: &str,
-    diagnostics: &mut Vec<Diagnostic>,
-) {
-    let timeout = mapping_value(mapping, "timeout-minutes").and_then(Yaml::as_i64);
-    if !timeout.is_some_and(|minutes| (1..=10).contains(&minutes)) {
-        diagnostics.push(Diagnostic::at(
-            path,
-            format!("`{location}` does not have a timeout from 1 through 10 minutes"),
-            "split the work into bounded jobs and keep every hosted runner at or below ten minutes",
-        ));
     }
 }
 

--- a/xtask/src/reproducibility/workflow_timeout.rs
+++ b/xtask/src/reproducibility/workflow_timeout.rs
@@ -1,0 +1,117 @@
+//! Bounded hosted execution with an explicit release-compilation allowance.
+
+use crate::error::Diagnostic;
+use std::path::Path;
+use yaml_rust2::Yaml;
+use yaml_rust2::yaml::Hash;
+
+pub(super) fn validate(
+    mapping: &Hash,
+    path: &Path,
+    location: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let maximum = if path == Path::new(".github/workflows/release.yml")
+        && matches!(
+            location,
+            "jobs.build-daemon-library"
+                | "jobs.build-cli-library"
+                | "jobs.build-binary"
+                | "jobs.check-native-staging"
+                | "jobs.distro-compile"
+                | "jobs.distro-compile-checks"
+        ) {
+        20
+    } else {
+        10
+    };
+    let timeout = mapping.get(&Yaml::String("timeout-minutes".into())).and_then(Yaml::as_i64);
+    if !timeout.is_some_and(|minutes| (1..=maximum).contains(&minutes)) {
+        diagnostics.push(Diagnostic::at(
+            path,
+            format!("`{location}` does not have a timeout from 1 through {maximum} minutes"),
+            "keep hosted jobs within ten minutes, except the named release compilation jobs within twenty",
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::reproducibility_workflow_tests::{assert_message, validate};
+    use super::super::workflow_files::DocumentKind;
+
+    const RELEASE_COMPILATION_JOBS: [&str; 6] = [
+        "build-daemon-library",
+        "build-cli-library",
+        "build-binary",
+        "check-native-staging",
+        "distro-compile",
+        "distro-compile-checks",
+    ];
+
+    fn timeout_workflow(job: &str, timeout: &str) -> String {
+        format!(
+            "name: timeout policy\njobs:\n  {job}:\n    runs-on: ubuntu-24.04\n    timeout-minutes: {timeout}\n    steps:\n      - run: cargo test --workspace --locked\n"
+        )
+    }
+
+    #[test]
+    fn named_release_compilation_jobs_accept_up_to_twenty_minutes() {
+        for job in RELEASE_COMPILATION_JOBS {
+            for timeout in ["1", "10", "11", "20"] {
+                let (_, diagnostics) = validate(
+                    ".github/workflows/release.yml",
+                    DocumentKind::Workflow,
+                    &timeout_workflow(job, timeout),
+                );
+                assert!(diagnostics.is_empty(), "{job}/{timeout}: {diagnostics:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn release_compilation_timeouts_reject_unbounded_or_noninteger_values() {
+        for job in RELEASE_COMPILATION_JOBS {
+            for timeout in ["0", "-1", "21", "\"20\"", "null", "", "1.5", "${{ inputs.timeout }}"] {
+                let (_, diagnostics) = validate(
+                    ".github/workflows/release.yml",
+                    DocumentKind::Workflow,
+                    &timeout_workflow(job, timeout),
+                );
+                assert_message(&diagnostics, "timeout from 1 through 20 minutes");
+            }
+        }
+    }
+
+    #[test]
+    fn release_timeout_exception_cannot_move_to_other_workflows_or_jobs() {
+        for job in RELEASE_COMPILATION_JOBS {
+            for path in [".github/workflows/extra.yml", ".github/workflows/release.yaml"] {
+                let (_, diagnostics) =
+                    validate(path, DocumentKind::Workflow, &timeout_workflow(job, "20"));
+                assert_message(&diagnostics, "timeout from 1 through 10 minutes");
+            }
+        }
+        for job in [
+            "policy",
+            "h2",
+            "bootstrap",
+            "assemble",
+            "compare-native",
+            "attest",
+            "distro-image",
+            "distro-build",
+            "distro-sign",
+            "stage-draft",
+            "build-h2-controller",
+            "build-cli-library-extra",
+        ] {
+            let (_, diagnostics) = validate(
+                ".github/workflows/release.yml",
+                DocumentKind::Workflow,
+                &timeout_workflow(job, "20"),
+            );
+            assert_message(&diagnostics, "timeout from 1 through 10 minutes");
+        }
+    }
+}


### PR DESCRIPTION
Implements the owner-approved 20-minute allowance for six named release compilation jobs. All other hosted jobs remain limited to ten minutes. Product code, release profiles, qualification, signing, candidate binding, and independent rebuild gates are unchanged.

The Intel Mac CLI library completed Cargo compilation but exceeded the old ten-minute job deadline before retaining its outputs. The new budget includes setup, compilation, transport, and upload.

Policy tests cover valid bounds, excessive and noninteger values, wrong workflow paths, and non-compilation jobs. Release workflow contract tests and documentation now describe the scoped exception.

Verified locally: 335 xtask unit tests, seven integration tests, 56 Python regressions, workspace formatting check, strict all-target/all-feature xtask Clippy, xtask all, actionlint, and staged diff checks. Tracks Crosslink issue 57. Release remains an unpublished draft pending application of this fix and a fresh tagged build.