### PR TITLE
fix(daemon): shorten the Unix endpoint name so macOS socket paths fit

### DIFF
--- a/crates/app/peritus-daemon/src/identity.rs
+++ b/crates/app/peritus-daemon/src/identity.rs
@@ -12,15 +12,19 @@ pub struct DaemonIdentity {
 
 impl DaemonIdentity {
     /// Derives a stable, non-secret endpoint name from one store identity.
+    ///
+    /// The name is `peritus-` followed by 16 hex characters. It is kept short because Unix socket
+    /// paths are limited to 103 bytes on macOS (`sun_path`), and the macOS state root under
+    /// `~/Library/Application Support/Peritus/State/daemon` already consumes most of that.
     #[must_use]
     pub fn new(store_id: StoreId) -> Self {
         let mut hasher = Sha256::new();
-        hasher.update(b"peritus/daemon-endpoint/v1\0");
+        hasher.update(b"peritus/daemon-endpoint/v2\0");
         hasher.update(store_id.as_bytes());
         let digest: [u8; 32] = hasher.finalize().into();
-        let mut endpoint_name = String::with_capacity(8 + 32);
+        let mut endpoint_name = String::with_capacity(8 + 16);
         endpoint_name.push_str("peritus-");
-        for byte in &digest[..16] {
+        for byte in &digest[..8] {
             use core::fmt::Write as _;
             write!(&mut endpoint_name, "{byte:02x}").expect("writing into String cannot fail");
         }

--- a/crates/app/peritus-daemon/src/ipc/unix.rs
+++ b/crates/app/peritus-daemon/src/ipc/unix.rs
@@ -76,6 +76,7 @@ impl PlatformEndpoint {
         let root = inspect_state_root(state_root)?;
         let owner_uid = root.uid();
         let path = state_root.join(format!("{}.sock", identity.endpoint_name()));
+        refuse_endpoint_path_too_long(&path)?;
         refuse_existing_endpoint(&path)?;
 
         let listener = UnixListener::bind(&path).map_err(bind_error)?;
@@ -202,6 +203,26 @@ fn inspect_state_root(state_root: &Path) -> Result<fs::Metadata, DaemonError> {
         ));
     }
     Ok(metadata)
+}
+
+/// Longest `sun_path` accepted by every supported Unix platform (macOS allows 104 bytes
+/// including the terminating NUL; Linux allows 108).
+const MAX_UNIX_ENDPOINT_PATH_BYTES: usize = 103;
+
+fn refuse_endpoint_path_too_long(path: &Path) -> Result<(), DaemonError> {
+    let length = path.as_os_str().len();
+    if length > MAX_UNIX_ENDPOINT_PATH_BYTES {
+        return Err(DaemonError::new(
+            DaemonErrorCode::Transport,
+            DaemonRecovery::Operator,
+            "bind Unix endpoint",
+            format!(
+                "Unix endpoint path is {length} bytes; the platform limit is {MAX_UNIX_ENDPOINT_PATH_BYTES}: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
 }
 
 fn refuse_existing_endpoint(path: &Path) -> Result<(), DaemonError> {

--- a/crates/app/testing/peritus-platform-qualification/src/native_controller/checks/daemon.rs
+++ b/crates/app/testing/peritus-platform-qualification/src/native_controller/checks/daemon.rs
@@ -221,9 +221,9 @@ fn native_temporary_parent() -> Result<PathBuf, std::io::Error> {
 
 fn endpoint_name() -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"peritus/daemon-endpoint/v1\0");
+    hasher.update(b"peritus/daemon-endpoint/v2\0");
     hasher.update(STORE_ID);
-    format!("peritus-{}", hex(&hasher.finalize()[..16]))
+    format!("peritus-{}", hex(&hasher.finalize()[..8]))
 }
 
 fn toml_path(path: &Path) -> String {

--- a/crates/app/testing/peritus-platform-qualification/src/transport.rs
+++ b/crates/app/testing/peritus-platform-qualification/src/transport.rs
@@ -47,16 +47,16 @@ impl StoreIdentity {
         self.0
     }
 
-    /// Derives the exact non-secret `peritus-<32-hex>` daemon endpoint name used by G0.
+    /// Derives the exact non-secret `peritus-<16-hex>` daemon endpoint name used by G0.
     #[must_use]
     pub fn endpoint_name(self) -> String {
         let mut hasher = Sha256::new();
-        hasher.update(b"peritus/daemon-endpoint/v1\0");
+        hasher.update(b"peritus/daemon-endpoint/v2\0");
         hasher.update(self.0);
         let digest: [u8; 32] = hasher.finalize().into();
-        let mut output = String::with_capacity(40);
+        let mut output = String::with_capacity(24);
         output.push_str("peritus-");
-        for byte in &digest[..16] {
+        for byte in &digest[..8] {
             use core::fmt::Write as _;
             write!(&mut output, "{byte:02x}").expect("writing to String cannot fail");
         }


### PR DESCRIPTION
Fixes #61.

## Problem

On macOS, `peritusd` exits during startup because its Unix socket path exceeds the platform limit, so `peritus` cannot launch the interactive product.

macOS `sun_path` is 104 bytes including the NUL terminator, giving a usable maximum of 103. The launcher hardcodes the macOS state root under `~/Library/Application Support/Peritus/State/daemon` (58 bytes with a two-letter username), and the endpoint name is `peritus-` plus 32 hex characters, so the full socket path is 104 bytes at minimum. Every macOS user is over the limit.

The log showed only the wrapper message ("Unix endpoint could not be created"); the real `io::Error` is `AF_UNIX path too long`.

## Change

- Derive the endpoint name from 8 digest bytes instead of 16 (`peritus-<16 hex>`), under a new domain tag `peritus/daemon-endpoint/v2`. This brings the macOS path to 88 bytes and leaves room for usernames up to 17 characters.
- Apply the same derivation in the two qualification-crate copies so they keep agreeing with the daemon.
- Refuse over-long endpoint paths at bind time with the path and the limit in the error, so a future regression is diagnosable from the log.

## Verification

Built and installed on macOS 15.6 (Apple Silicon) with `cargo xtask product-install`, then started the daemon with the launcher-generated config:

```
srw------- /Users/jp/Library/Application Support/Peritus/State/daemon/peritus-ea9947888178618b.sock   (88 bytes)
$ peritus --endpoint <socket> status
daemon ready-read-write; session=cad1cd682f919ead4123166b8b1cf8ee
$ peritus --endpoint <socket> shutdown --wait
shutdown clean; remaining=0
```

- `cargo test -p peritus-daemon --lib identity` passes.
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p peritus-daemon -p peritus-platform-qualification --all-targets -- -D warnings` clean.

Note: the daemon still cannot be reached through the `peritus` symlink until #60 is fixed; that is a separate launcher change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE1uWZ79cxKfgmgDiR8CKr
