### PR TITLE
fix: preserve command identities across runtime restarts

### DIFF
--- a/crates/app/peritus-product-runner/README.md
+++ b/crates/app/peritus-product-runner/README.md
@@ -55,6 +55,13 @@ or control with the existing C4/C2 owner; it does not promise to recreate an arb
 after a daemon process restart. Startup recovery separately reconciles durable C2 process state and
 the durable product run remains explicitly recoverable.
 
+New shell and local-compactor commands reserve a durable per-run ordinal before creating process
+authority. Reopening the runtime, a failed start, and concurrent runtime instances cannot reuse a
+reserved identity. The transactional SQLite allocator also skips existing authority and compactor
+paths from older versions. Failed starts consume an ordinal; an unreadable or exhausted allocator
+stops execution rather than resetting it. Effect receipts still determine whether an earlier
+request may replay a result or requires reconciliation.
+
 When the launcher supplied explicit automatic-failover consent, every designer, writer, reviewer,
 and fixer invocation owns a deterministic provider cursor. The selected provider keeps its normal
 bounded recovery first. Only then may the role advance to another configured tool-capable route;

--- a/crates/app/peritus-product-runner/src/developer_tools/command_runtime/compactor.rs
+++ b/crates/app/peritus-product-runner/src/developer_tools/command_runtime/compactor.rs
@@ -44,9 +44,13 @@ impl CommandRuntime {
         let ordinal = {
             let mut state =
                 self.inner.state.lock().map_err(|_| "local compactor command owner poisoned")?;
-            state.next_ordinal =
-                state.next_ordinal.checked_add(1).ok_or("local compactor ordinal overflow")?;
-            state.next_ordinal
+            let ordinal = super::ordinal::reserve(
+                &self.inner.state_root,
+                self.inner.run_id,
+                state.next_ordinal,
+            )?;
+            state.next_ordinal = ordinal;
+            ordinal
         };
         let contract = contract::command_contract(self.inner.run_id, ordinal)?;
         let ids = identity::CommandIds::new(self.inner.run_id, ordinal, &contract)?;

--- a/crates/app/peritus-product-runner/src/developer_tools/command_runtime/mod.rs
+++ b/crates/app/peritus-product-runner/src/developer_tools/command_runtime/mod.rs
@@ -10,6 +10,7 @@ mod identity;
 mod journal;
 mod kernel;
 mod lease;
+mod ordinal;
 mod plan;
 mod preview;
 mod result;
@@ -155,11 +156,10 @@ impl CommandRuntime {
         let timeout_millis =
             u64::try_from(request.timeout.as_millis()).unwrap_or(u64::MAX).clamp(1, 600_000);
         let mut state = self.inner.state.lock().map_err(|_| tool("command runtime is poisoned"))?;
-        state.next_ordinal = state
-            .next_ordinal
-            .checked_add(1)
-            .ok_or_else(|| tool("command runtime action ordinal overflowed"))?;
-        let ordinal = state.next_ordinal;
+        let ordinal =
+            ordinal::reserve(&self.inner.state_root, self.inner.run_id, state.next_ordinal)
+                .map_err(tool)?;
+        state.next_ordinal = ordinal;
         let contract = contract::command_contract(self.inner.run_id, ordinal).map_err(tool)?;
         let ids = identity::CommandIds::new(self.inner.run_id, ordinal, &contract).map_err(tool)?;
         let command = plan::compile(

--- a/crates/app/peritus-product-runner/src/developer_tools/command_runtime/ordinal.rs
+++ b/crates/app/peritus-product-runner/src/developer_tools/command_runtime/ordinal.rs
@@ -1,0 +1,155 @@
+//! Durable allocation of fresh command identities across runtime instances.
+//!
+//! Effect receipts decide whether a request may execute before shell allocation.
+//! This allocator reserves numbers for admitted new work; it does not recover or
+//! redispatch previous effects. Failed starts deliberately leave reserved gaps.
+
+use std::{fs, path::Path, time::Duration};
+
+use peritus_types::{ActionId, RunId};
+use rusqlite::{Connection, TransactionBehavior, params};
+
+use super::{contract, identity};
+
+/// Reserves a number before any authority journal or process can be created.
+/// SQLite serializes reservations across independently opened runtimes. Legacy
+/// authority and compactor paths remain occupied even without an allocator row.
+pub(super) fn reserve(root: &Path, run_id: RunId, after: u64) -> Result<u64, String> {
+    let mut connection = Connection::open(root.join("command-ordinals.sqlite3")).map_err(detail)?;
+    connection.busy_timeout(Duration::from_millis(250)).map_err(detail)?;
+    connection.pragma_update(None, "synchronous", "FULL").map_err(detail)?;
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS command_ordinals (
+            run_id BLOB PRIMARY KEY NOT NULL CHECK(length(run_id) = 16),
+            last_ordinal INTEGER NOT NULL
+                CHECK(typeof(last_ordinal) = 'integer' AND last_ordinal >= 0)
+        );",
+        )
+        .map_err(detail)?;
+    let transaction =
+        connection.transaction_with_behavior(TransactionBehavior::Immediate).map_err(detail)?;
+    transaction
+        .execute(
+            "INSERT INTO command_ordinals(run_id, last_ordinal) VALUES (?1, 0)
+         ON CONFLICT(run_id) DO NOTHING",
+            params![run_id.as_bytes().as_slice()],
+        )
+        .map_err(detail)?;
+    let stored: i64 = transaction
+        .query_row(
+            "SELECT last_ordinal FROM command_ordinals WHERE run_id = ?1",
+            params![run_id.as_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .map_err(detail)?;
+    let mut ordinal = u64::try_from(stored)
+        .map_err(|_| "command ordinal store contains a negative number".to_owned())?
+        .max(after);
+    loop {
+        ordinal = ordinal
+            .checked_add(1)
+            .filter(|value| *value <= i64::MAX as u64)
+            .ok_or_else(|| "command runtime action ordinal overflowed".to_owned())?;
+        let action = ActionId::new(contract::id(run_id, ordinal, "action"))
+            .map_err(|error| format!("construct reserved command identity: {error:?}"))?;
+        let action = identity::action_hex(action);
+        if !occupied(&root.join("authority").join(&action))?
+            && !occupied(&root.join("local-compactor").join(&action))?
+        {
+            break;
+        }
+    }
+    let stored = i64::try_from(ordinal)
+        .map_err(|_| "command runtime action ordinal overflowed".to_owned())?;
+    transaction
+        .execute(
+            "UPDATE command_ordinals SET last_ordinal = ?1 WHERE run_id = ?2",
+            params![stored, run_id.as_bytes().as_slice()],
+        )
+        .map_err(detail)?;
+    // Never expose an allocation whose durable commit was not acknowledged.
+    transaction.commit().map_err(detail)?;
+    Ok(ordinal)
+}
+
+fn occupied(path: &Path) -> Result<bool, String> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!("inspect existing command identity: {error}")),
+    }
+}
+
+fn detail(error: rusqlite::Error) -> String {
+    format!("reserve durable command ordinal: {error}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reopening_and_stale_local_counters_do_not_reuse_reservations() {
+        let root = tempfile::tempdir().expect("state directory");
+        let run = RunId::new([1; 16]).expect("run");
+        assert_eq!(reserve(root.path(), run, 0).expect("first"), 1);
+        // Every reserve opens a separate connection. No authority file is needed
+        // for a reservation to survive a failed start or runtime restart.
+        assert_eq!(reserve(root.path(), run, 0).expect("reopened"), 2);
+        assert_eq!(reserve(root.path(), run, 1).expect("stale instance"), 3);
+        assert_eq!(reserve(root.path(), run, 9).expect("local high water"), 10);
+        assert_eq!(reserve(root.path(), run, 0).expect("reopened again"), 11);
+    }
+
+    #[test]
+    fn legacy_shell_and_compactor_identities_are_preserved_including_gaps() {
+        let root = tempfile::tempdir().expect("state directory");
+        let run = RunId::new([2; 16]).expect("run");
+        for (ordinal, directory) in [(1, "authority"), (3, "local-compactor")] {
+            let action = ActionId::new(contract::id(run, ordinal, "action")).expect("action");
+            let path = root.path().join(directory).join(identity::action_hex(action));
+            fs::create_dir_all(&path).expect("legacy identity");
+            fs::write(path.join("preserved"), b"legacy evidence").expect("evidence");
+        }
+        assert_eq!(reserve(root.path(), run, 0).expect("first free"), 2);
+        assert_eq!(reserve(root.path(), run, 0).expect("skip later legacy"), 4);
+        for (ordinal, directory) in [(1, "authority"), (3, "local-compactor")] {
+            let action = ActionId::new(contract::id(run, ordinal, "action")).expect("action");
+            let path = root.path().join(directory).join(identity::action_hex(action));
+            assert_eq!(fs::read(path.join("preserved")).expect("retained"), b"legacy evidence");
+        }
+    }
+
+    #[test]
+    fn independent_threads_reserve_distinct_numbers() {
+        let root = tempfile::tempdir().expect("state directory");
+        let run = RunId::new([3; 16]).expect("run");
+        assert_eq!(reserve(root.path(), run, 0).expect("initialize"), 1);
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(4));
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let path = root.path().to_path_buf();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    reserve(&path, run, 0).expect("concurrent allocation")
+                })
+            })
+            .collect();
+        let mut values: Vec<_> =
+            handles.into_iter().map(|handle| handle.join().expect("allocation thread")).collect();
+        values.sort_unstable();
+        assert_eq!(values, vec![2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn malformed_store_and_exhaustion_fail_without_resetting_identity() {
+        let root = tempfile::tempdir().expect("state directory");
+        let run = RunId::new([4; 16]).expect("run");
+        assert!(reserve(root.path(), run, u64::MAX).is_err());
+        fs::write(root.path().join("command-ordinals.sqlite3"), b"invalid database")
+            .expect("damaged fixture");
+        assert!(reserve(root.path(), run, 0).is_err());
+    }
+}

--- a/crates/app/peritus-product-runner/src/developer_tools/command_runtime/ordinal.rs
+++ b/crates/app/peritus-product-runner/src/developer_tools/command_runtime/ordinal.rs
@@ -12,12 +12,15 @@ use rusqlite::{Connection, TransactionBehavior, params};
 use super::{contract, identity};
 
 /// Reserves a number before any authority journal or process can be created.
-/// SQLite serializes reservations across independently opened runtimes. Legacy
+/// `SQLite` serializes reservations across independently opened runtimes. Legacy
 /// authority and compactor paths remain occupied even without an allocator row.
 pub(super) fn reserve(root: &Path, run_id: RunId, after: u64) -> Result<u64, String> {
-    let mut connection = Connection::open(root.join("command-ordinals.sqlite3")).map_err(detail)?;
-    connection.busy_timeout(Duration::from_millis(250)).map_err(detail)?;
-    connection.pragma_update(None, "synchronous", "FULL").map_err(detail)?;
+    let mut connection =
+        Connection::open(root.join("command-ordinals.sqlite3")).map_err(|error| detail(&error))?;
+    connection.busy_timeout(Duration::from_millis(250)).map_err(|error| detail(&error))?;
+    // EXTRA also syncs the rollback-journal directory after commit. FULL alone
+    // can lose the last acknowledged reservation on power loss in DELETE mode.
+    connection.pragma_update(None, "synchronous", "EXTRA").map_err(|error| detail(&error))?;
     connection
         .execute_batch(
             "CREATE TABLE IF NOT EXISTS command_ordinals (
@@ -26,30 +29,31 @@ pub(super) fn reserve(root: &Path, run_id: RunId, after: u64) -> Result<u64, Str
                 CHECK(typeof(last_ordinal) = 'integer' AND last_ordinal >= 0)
         );",
         )
-        .map_err(detail)?;
-    let transaction =
-        connection.transaction_with_behavior(TransactionBehavior::Immediate).map_err(detail)?;
+        .map_err(|error| detail(&error))?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| detail(&error))?;
     transaction
         .execute(
             "INSERT INTO command_ordinals(run_id, last_ordinal) VALUES (?1, 0)
          ON CONFLICT(run_id) DO NOTHING",
             params![run_id.as_bytes().as_slice()],
         )
-        .map_err(detail)?;
+        .map_err(|error| detail(&error))?;
     let stored: i64 = transaction
         .query_row(
             "SELECT last_ordinal FROM command_ordinals WHERE run_id = ?1",
             params![run_id.as_bytes().as_slice()],
             |row| row.get(0),
         )
-        .map_err(detail)?;
+        .map_err(|error| detail(&error))?;
     let mut ordinal = u64::try_from(stored)
         .map_err(|_| "command ordinal store contains a negative number".to_owned())?
         .max(after);
     loop {
         ordinal = ordinal
             .checked_add(1)
-            .filter(|value| *value <= i64::MAX as u64)
+            .filter(|value| i64::try_from(*value).is_ok())
             .ok_or_else(|| "command runtime action ordinal overflowed".to_owned())?;
         let action = ActionId::new(contract::id(run_id, ordinal, "action"))
             .map_err(|error| format!("construct reserved command identity: {error:?}"))?;
@@ -67,9 +71,9 @@ pub(super) fn reserve(root: &Path, run_id: RunId, after: u64) -> Result<u64, Str
             "UPDATE command_ordinals SET last_ordinal = ?1 WHERE run_id = ?2",
             params![stored, run_id.as_bytes().as_slice()],
         )
-        .map_err(detail)?;
+        .map_err(|error| detail(&error))?;
     // Never expose an allocation whose durable commit was not acknowledged.
-    transaction.commit().map_err(detail)?;
+    transaction.commit().map_err(|error| detail(&error))?;
     Ok(ordinal)
 }
 
@@ -81,7 +85,7 @@ fn occupied(path: &Path) -> Result<bool, String> {
     }
 }
 
-fn detail(error: rusqlite::Error) -> String {
+fn detail(error: &rusqlite::Error) -> String {
     format!("reserve durable command ordinal: {error}")
 }
 
@@ -123,24 +127,70 @@ mod tests {
 
     #[test]
     fn independent_threads_reserve_distinct_numbers() {
+        for initialized in [false, true] {
+            concurrent_reservations(initialized);
+        }
+    }
+
+    fn concurrent_reservations(initialized: bool) {
         let root = tempfile::tempdir().expect("state directory");
         let run = RunId::new([3; 16]).expect("run");
-        assert_eq!(reserve(root.path(), run, 0).expect("initialize"), 1);
+        let offset =
+            if initialized { reserve(root.path(), run, 0).expect("initialize") } else { 0 };
         let barrier = std::sync::Arc::new(std::sync::Barrier::new(4));
-        let handles: Vec<_> = (0..4)
-            .map(|_| {
-                let path = root.path().to_path_buf();
-                let barrier = barrier.clone();
-                std::thread::spawn(move || {
-                    barrier.wait();
-                    reserve(&path, run, 0).expect("concurrent allocation")
-                })
-            })
-            .collect();
+        // Start every worker before joining: joining a lazy spawn iterator would deadlock
+        // the barrier and would no longer exercise simultaneous reservations.
+        let mut handles = Vec::with_capacity(4);
+        for _ in 0..4 {
+            let path = root.path().to_path_buf();
+            let barrier = std::sync::Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                reserve(&path, run, 0).expect("concurrent allocation")
+            }));
+        }
         let mut values: Vec<_> =
             handles.into_iter().map(|handle| handle.join().expect("allocation thread")).collect();
         values.sort_unstable();
-        assert_eq!(values, vec![2, 3, 4, 5]);
+        assert_eq!(values, vec![offset + 1, offset + 2, offset + 3, offset + 4]);
+        assert_eq!(reserve(root.path(), run, 0).expect("reopen after contention"), offset + 5);
+    }
+
+    #[test]
+    fn separate_runs_retain_independent_high_water_marks() {
+        let root = tempfile::tempdir().expect("state directory");
+        let first = RunId::new([5; 16]).expect("first run");
+        let second = RunId::new([6; 16]).expect("second run");
+        assert_eq!(reserve(root.path(), first, 0).expect("first reservation"), 1);
+        assert_eq!(reserve(root.path(), second, 0).expect("second run reservation"), 1);
+        assert_eq!(reserve(root.path(), first, 0).expect("first run reopened"), 2);
+        assert_eq!(reserve(root.path(), second, 0).expect("second run reopened"), 2);
+    }
+
+    #[test]
+    fn invalid_and_exhausted_stored_counters_are_never_reset() {
+        for stored in [
+            rusqlite::types::Value::Integer(-1),
+            rusqlite::types::Value::Text("invalid ordinal".to_owned()),
+            rusqlite::types::Value::Integer(i64::MAX),
+        ] {
+            let root = tempfile::tempdir().expect("state directory");
+            let run = RunId::new([7; 16]).expect("run");
+            assert_eq!(reserve(root.path(), run, 0).expect("initialize"), 1);
+            let connection = Connection::open(root.path().join("command-ordinals.sqlite3"))
+                .expect("open fixture");
+            connection
+                .pragma_update(None, "ignore_check_constraints", true)
+                .expect("permit corrupt fixture");
+            connection
+                .execute("UPDATE command_ordinals SET last_ordinal = ?1", params![stored])
+                .expect("write stored counter fixture");
+            assert!(reserve(root.path(), run, 0).is_err());
+            let retained: rusqlite::types::Value = connection
+                .query_row("SELECT last_ordinal FROM command_ordinals", [], |row| row.get(0))
+                .expect("read retained counter");
+            assert_eq!(retained, stored);
+        }
     }
 
     #[test]

--- a/crates/app/peritus-product-runner/src/developer_tools/command_runtime/tests.rs
+++ b/crates/app/peritus-product-runner/src/developer_tools/command_runtime/tests.rs
@@ -1,21 +1,21 @@
 use super::identity::bounded_key;
 
-#[cfg(unix)]
 #[test]
-#[ignore = "subprocess fixture invoked by the runtime restart test"]
 fn command_restart_fixture() {
     use std::io::Write as _;
 
-    let marker = std::fs::read_to_string("restart-marker.txt").expect("subprocess input");
+    let Ok(marker) = std::env::var("PERITUS_COMMAND_RESTART_FIXTURE") else { return };
     assert!(matches!(marker.as_str(), "first" | "second"));
     let mut effects = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open("effects.txt")
         .expect("open command effects");
-    writeln!(effects, "{marker}").expect("record command effect");
+    effects.write_all(format!("{marker}\n").as_bytes()).expect("record command effect");
     effects.flush().expect("flush command effect");
-    println!("restart-effect:{marker}");
+    let mut output = std::io::stdout();
+    output.write_all(format!("restart-effect:{marker}\n").as_bytes()).expect("report effect");
+    output.flush().expect("flush effect observation");
 }
 
 #[test]
@@ -26,9 +26,8 @@ fn idempotency_keys_are_stable_and_fixed_width() {
     assert_eq!(first.len(), 64);
 }
 
-#[cfg(unix)]
 #[test]
-fn commands_after_runtime_reopen_have_distinct_identities_and_execute_once() {
+fn commands_after_failed_start_and_runtime_reopen_execute_once_with_fresh_identities() {
     use super::{CommandRuntime, StartCommand};
     use peritus_process::ProcessStore;
     use peritus_types::RunId;
@@ -45,8 +44,8 @@ fn commands_after_runtime_reopen_have_distinct_identities_and_execute_once() {
             .expect("process store");
         let mut handles = Vec::new();
 
-        for marker in ["first", "second"] {
-            let runtime = if direct {
+        let open_runtime = || {
+            if direct {
                 CommandRuntime::open_direct(
                     state.path().join("router"),
                     workspace.path(),
@@ -61,13 +60,34 @@ fn commands_after_runtime_reopen_have_distinct_identities_and_execute_once() {
                     processes.clone(),
                 )
             }
-            .expect("open runtime with the same run and durable state");
-            std::fs::write(workspace.path().join("restart-marker.txt"), marker)
-                .expect("subprocess input");
+            .expect("open runtime with the same run and durable state")
+        };
+        {
+            let runtime = open_runtime();
+            let missing = workspace.path().join("missing-command-executable");
+            assert!(
+                runtime
+                    .run(StartCommand {
+                        program: missing.to_str().expect("missing executable path"),
+                        arguments: &[],
+                        cwd: workspace.path(),
+                        timeout: Duration::from_secs(10),
+                        interactive: false,
+                        rows: 24,
+                        columns: 80,
+                        idempotency_key: "failed-start",
+                        environment: vec![],
+                    })
+                    .is_err()
+            );
+        }
+        assert!(!workspace.path().join("effects.txt").exists());
+
+        for (marker, ordinal) in [("first", 2), ("second", 3)] {
+            let runtime = open_runtime();
             let arguments = vec![
                 "--exact".to_owned(),
                 "developer_tools::command_runtime::tests::command_restart_fixture".to_owned(),
-                "--ignored".to_owned(),
                 "--nocapture".to_owned(),
             ];
             let result = runtime
@@ -80,7 +100,10 @@ fn commands_after_runtime_reopen_have_distinct_identities_and_execute_once() {
                     rows: 24,
                     columns: 80,
                     idempotency_key: marker,
-                    environment: Vec::new(),
+                    environment: vec![(
+                        "PERITUS_COMMAND_RESTART_FIXTURE".to_owned(),
+                        marker.to_owned(),
+                    )],
                 })
                 .expect("execute command across runtime restart");
             assert_eq!(result["success"].as_bool(), Some(true), "{result}");
@@ -93,6 +116,9 @@ fn commands_after_runtime_reopen_have_distinct_identities_and_execute_once() {
                 "{result}"
             );
             handles.push(result["handle"].as_str().expect("command handle").to_owned());
+            let action = peritus_types::ActionId::new(super::contract::id(run, ordinal, "action"))
+                .expect("expected fresh action");
+            assert_eq!(handles.last(), Some(&super::identity::action_hex(action)));
             drop(runtime);
         }
 

--- a/crates/app/peritus-product-runner/src/developer_tools/command_runtime/tests.rs
+++ b/crates/app/peritus-product-runner/src/developer_tools/command_runtime/tests.rs
@@ -1,9 +1,105 @@
 use super::identity::bounded_key;
 
+#[cfg(unix)]
+#[test]
+#[ignore = "subprocess fixture invoked by the runtime restart test"]
+fn command_restart_fixture() {
+    use std::io::Write as _;
+
+    let marker = std::fs::read_to_string("restart-marker.txt").expect("subprocess input");
+    assert!(matches!(marker.as_str(), "first" | "second"));
+    let mut effects = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("effects.txt")
+        .expect("open command effects");
+    writeln!(effects, "{marker}").expect("record command effect");
+    effects.flush().expect("flush command effect");
+    println!("restart-effect:{marker}");
+}
+
 #[test]
 fn idempotency_keys_are_stable_and_fixed_width() {
     let first = bounded_key("provider-call-17");
     assert_eq!(first, bounded_key("provider-call-17"));
     assert_ne!(first, bounded_key("provider-call-18"));
     assert_eq!(first.len(), 64);
+}
+
+#[cfg(unix)]
+#[test]
+fn commands_after_runtime_reopen_have_distinct_identities_and_execute_once() {
+    use super::{CommandRuntime, StartCommand};
+    use peritus_process::ProcessStore;
+    use peritus_types::RunId;
+    use std::time::Duration;
+
+    let executable = std::env::current_exe().expect("current test executable");
+    let program = executable.to_str().expect("test executable path");
+
+    for direct in [false, true] {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let state = tempfile::tempdir().expect("command state");
+        let run = RunId::new([17; 16]).expect("run identity");
+        let processes = ProcessStore::open(state.path().join("processes"), workspace.path())
+            .expect("process store");
+        let mut handles = Vec::new();
+
+        for marker in ["first", "second"] {
+            let runtime = if direct {
+                CommandRuntime::open_direct(
+                    state.path().join("router"),
+                    workspace.path(),
+                    run,
+                    processes.clone(),
+                )
+            } else {
+                CommandRuntime::open(
+                    state.path().join("router"),
+                    workspace.path(),
+                    run,
+                    processes.clone(),
+                )
+            }
+            .expect("open runtime with the same run and durable state");
+            std::fs::write(workspace.path().join("restart-marker.txt"), marker)
+                .expect("subprocess input");
+            let arguments = vec![
+                "--exact".to_owned(),
+                "developer_tools::command_runtime::tests::command_restart_fixture".to_owned(),
+                "--ignored".to_owned(),
+                "--nocapture".to_owned(),
+            ];
+            let result = runtime
+                .run(StartCommand {
+                    program,
+                    arguments: &arguments,
+                    cwd: workspace.path(),
+                    timeout: Duration::from_secs(10),
+                    interactive: false,
+                    rows: 24,
+                    columns: 80,
+                    idempotency_key: marker,
+                    environment: Vec::new(),
+                })
+                .expect("execute command across runtime restart");
+            assert_eq!(result["success"].as_bool(), Some(true), "{result}");
+            assert_eq!(result["exit_code"].as_i64(), Some(0), "{result}");
+            let expected_output = format!("restart-effect:{marker}");
+            assert!(
+                result["stdout"]
+                    .as_str()
+                    .is_some_and(|output| output.lines().any(|line| line == expected_output)),
+                "{result}"
+            );
+            handles.push(result["handle"].as_str().expect("command handle").to_owned());
+            drop(runtime);
+        }
+
+        assert_ne!(handles[0], handles[1]);
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("effects.txt")).expect("command effects"),
+            "first\nsecond\n",
+        );
+    }
 }


### PR DESCRIPTION
Reopening the command runtime reset its in-memory counter while retaining earlier command journals. New commands could reuse an existing identity and fail with `PERITUS-JOURNAL-CAS-001`.

Shell commands and the local compactor now reserve per-run ordinals in an immediate SQLite transaction before creating authority or starting a process. Reservations survive runtime reopening and failed starts, serialize concurrent allocations, and skip occupied legacy authority paths. Unreadable, invalid, or exhausted counters stop execution without resetting identities. Existing journals and effect-recovery rules remain intact.

The allocator uses SQLite's `synchronous=EXTRA` so rollback-journal deletion is synced before acknowledging a reservation, following [SQLite's durability guidance](https://www.sqlite.org/pragma.html#pragma_synchronous).

Regression coverage includes cold and initialized concurrent startup, stale local counters, separate run IDs, legacy identity gaps, malformed storage, persisted counter exhaustion, and failed starts followed by runtime reopening. The portable restart fixture runs real commands through both command backends and checks fresh handles, observed output, and exactly one recorded effect per command.

Local validation passed:

- Workspace formatting, strict Clippy with all targets/features, and `cargo xtask all`.
- Full product-runner suite: 281 passed; one existing preview subprocess fixture remains intentionally ignored by the harness and is invoked by its owning test.
- Edge CI shard: 478 passed across nine packages.
- Daemon product/recovery partition: six passed, including automatic restart recovery and preservation of explicit cancellation.
- Product-runner Verus verification with `--no-cheating` and the pinned toolchain.
- Windows GNU test build; six allocator tests and the failed-start/reopen test passed under Wine, including real execution through both command backends.

Native Linux, Windows, and macOS validation is provided by the PR workflows.
