### PR TITLE
fix(providers): accept repeated streamed usage snapshots

### DIFF
--- a/crates/model/peritus-provider-compatible/src/stream/chat.rs
+++ b/crates/model/peritus-provider-compatible/src/stream/chat.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 
 use peritus_model_protocol::{
     EventId, FinishReason, ItemId, ItemKind, ModelEvent, ModelName, ProtocolLimits, ProviderName,
-    ResponseId, StreamFragment,
+    ResponseId, StreamFragment, UsageCounters, UsageObservation, UsageScope,
 };
 use peritus_provider_core::{ProviderCoreError, SseFrame};
 use serde_json::{Map, Value};
@@ -34,6 +34,7 @@ pub(super) struct ChatDecoder {
     refusal_bytes: Vec<u8>,
     tools: BTreeMap<u32, ToolState>,
     finish: Option<hosted::CompletedChoice>,
+    usage: Option<Box<UsageCounters>>,
 }
 
 impl ChatDecoder {
@@ -63,6 +64,7 @@ impl ChatDecoder {
             refusal_bytes: Vec::new(),
             tools: BTreeMap::new(),
             finish: None,
+            usage: None,
         }
     }
 
@@ -138,7 +140,7 @@ impl ChatDecoder {
                     "Chat-compatible usage was not declared by the profile",
                 ));
             }
-            events.push(ModelEvent::Usage(fields::usage(usage)?));
+            self.observe_usage(usage, &mut events)?;
         }
         if value.get("provider_metadata").is_some() {
             let metadata = value
@@ -152,7 +154,7 @@ impl ChatDecoder {
             if let Some(usage) = metadata.get("usage").filter(|value| !value.is_null())
                 && self.allow_usage
             {
-                events.push(ModelEvent::Usage(fields::usage(usage)?));
+                self.observe_usage(usage, &mut events)?;
             }
             events.push(super::ancillary::event(
                 &serde_json::json!({"x_groq":metadata}),
@@ -180,7 +182,28 @@ impl ChatDecoder {
         {
             return Err(error::malformed("Chat-compatible DONE preceded a mapped finish"));
         }
-        Ok(vec![ModelEvent::ResponseCompleted])
+        let mut events = Vec::with_capacity(usize::from(self.usage.is_some()) + 1);
+        if let Some(usage) = self.usage.as_deref() {
+            events.push(ModelEvent::Usage(UsageObservation::new(UsageScope::Final, *usage, None)));
+        }
+        events.push(ModelEvent::ResponseCompleted);
+        Ok(events)
+    }
+
+    fn observe_usage(
+        &mut self,
+        value: &Value,
+        events: &mut Vec<ModelEvent>,
+    ) -> Result<(), ProviderCoreError> {
+        let observation = fields::usage(value)?;
+        let counters = observation.counters();
+        if let Some(usage) = self.usage.as_deref_mut() {
+            *usage = counters;
+        } else {
+            self.usage = Some(Box::new(counters));
+        }
+        events.push(ModelEvent::Usage(observation));
+        Ok(())
     }
 
     fn choice(

--- a/crates/model/peritus-provider-compatible/src/stream/chat/fields.rs
+++ b/crates/model/peritus-provider-compatible/src/stream/chat/fields.rs
@@ -44,7 +44,7 @@ pub(super) fn usage(value: &Value) -> Result<UsageObservation, ProviderCoreError
         return Err(error::malformed("Chat-compatible usage total was inconsistent"));
     }
     Ok(UsageObservation::new(
-        UsageScope::Final,
+        UsageScope::Cumulative,
         UsageCounters::new(prompt, None, None, completion, None, None, total, None),
         None,
     ))

--- a/crates/model/peritus-provider-compatible/src/tests/hosted.rs
+++ b/crates/model/peritus-provider-compatible/src/tests/hosted.rs
@@ -138,6 +138,13 @@ fn success(service: HostedService, step: usize) -> Vec<u8> {
             Value::Null,
         ));
     }
+    if service == HostedService::OpenCodeZen {
+        // Zen may stream more than one cumulative usage snapshot before its terminal accounting.
+        let mut usage = chunk(step, serde_json::json!({}), Value::Null);
+        usage["usage"] =
+            serde_json::json!({"prompt_tokens":1,"completion_tokens":1,"total_tokens":2});
+        chunks.push(usage);
+    }
     let reason = if step == 2 { "tool_calls" } else { "stop" };
     let mut last = chunk(step, serde_json::json!({}), serde_json::json!(reason));
     let usage = serde_json::json!({"prompt_tokens":2,"completion_tokens":3,"total_tokens":5});
@@ -202,7 +209,7 @@ fn client(
 }
 
 #[test]
-fn every_named_chat_contract_completes_generation_tools_and_reasoning_replay() {
+fn every_named_chat_contract_completes_generation_tools_usage_and_reasoning_replay() {
     block_on(async {
         for service in HostedService::ALL {
             let (client, transport) = client(service, None);

--- a/docs/provider-contracts.md
+++ b/docs/provider-contracts.md
@@ -50,9 +50,11 @@ function result with the original call's name and ID.
 
 Streams accept empty initial content as a heartbeat. OpenRouter's content-free final usage
 choice may repeat the preceding finish reason exactly once; it cannot introduce output or change
-the finish. Its HTTP-200 error events remain failures, including an error as the first event.
-Groq's `x_groq` accounting is retained. Named routes may resolve a requested model alias to a
-stable returned model ID; the returned ID cannot change during the stream.
+the finish. Chat-compatible usage snapshots remain cumulative while the stream is open; the last
+snapshot becomes final only at the mapped `[DONE]` boundary. Counter regressions still fail closed.
+OpenRouter's HTTP-200 error events remain failures, including an error as the first event. Groq's
+`x_groq` accounting is retained. Named routes may resolve a requested model alias to a stable
+returned model ID; the returned ID cannot change during the stream.
 
 Documented reasoning fields are preserved as bounded provider-specific replay data, including
 OpenRouter `reasoning_details` and DeepSeek/Fireworks `reasoning_content`. The developer loop keeps


### PR DESCRIPTION
OpenCode Zen can emit more than one increasing usage snapshot while a Chat Completions stream is still open. The compatible adapter labeled every snapshot final, so the reducer rejected the second one during connection-test tool calling with `usage observation regressed or followed final usage`.

This change emits streamed snapshots as cumulative, retains the latest counters, and emits one final snapshot when `[DONE]` closes the mapped response. Decreasing counters and observations after the final boundary remain rejected. The named-provider contract now reproduces the repeated OpenCode usage shape across generation, tool calling, and tool-result qualification.

Validation:

- Exact regression failed before the fix at the OpenCode Zen tool-calling stage and passes afterward.
- `cargo test --locked -p peritus-provider-compatible` (25 passed)
- `cargo xtask ci-shard test model-orchestration` (19 packages passed)
- `cargo xtask ci-shard build model-orchestration`
- `cargo xtask ci-shard doc-test model-orchestration`
- `cargo xtask ci-shard clippy model-orchestration`
- `cargo xtask ci-shard docs model-orchestration`
- `cargo xtask all`
- `cargo xtask docs-check`
- `cargo fmt --all -- --check`
- `cargo xtask discovery-replay`
